### PR TITLE
Remove SubscribeAll, UnsubscribeAll and Close if nothing in it

### DIFF
--- a/examples/library/app/generated/app.gen.go
+++ b/examples/library/app/generated/app.gen.go
@@ -49,6 +49,11 @@ func (ac *AppController) UnsubscribeAll() {
 	ac.UnsubscribeBooksListRequest()
 }
 
+// Close will clean up any existing resources on the controller
+func (ac *AppController) Close() {
+	ac.UnsubscribeAll()
+}
+
 // SubscribeBooksListRequest will subscribe to new messages from 'books.list.request' channel
 func (ac *AppController) SubscribeBooksListRequest(fn func(msg BooksListRequestMessage)) error {
 	// Subscribe to broker channel
@@ -65,7 +70,7 @@ func (ac *AppController) SubscribeBooksListRequest(fn func(msg BooksListRequestM
 		for open := true; open; {
 			um, open = <-msgs
 
-			err := json.Unmarshal(um.Payload, &msg)
+			err := json.Unmarshal(um.Payload, &msg.Payload)
 			if err != nil {
 				log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
 				continue
@@ -92,11 +97,6 @@ func (ac *AppController) UnsubscribeBooksListRequest() {
 
 	stopChan <- true
 	delete(ac.stopSubscribers, "books.list.request")
-}
-
-// Close will clean up any existing resources on the controller
-func (ac *AppController) Close() {
-	ac.UnsubscribeAll()
 }
 
 // PublishBooksListResponse will publish messages to 'books.list.response' channel

--- a/examples/library/client/generated/client.gen.go
+++ b/examples/library/client/generated/client.gen.go
@@ -49,6 +49,11 @@ func (cc *ClientController) UnsubscribeAll() {
 	cc.UnsubscribeBooksListResponse()
 }
 
+// Close will clean up any existing resources on the controller
+func (cc *ClientController) Close() {
+	cc.UnsubscribeAll()
+}
+
 // SubscribeBooksListResponse will subscribe to new messages from 'books.list.response' channel
 func (cc *ClientController) SubscribeBooksListResponse(fn func(msg BooksListResponseMessage)) error {
 	// Subscribe to broker channel
@@ -65,7 +70,7 @@ func (cc *ClientController) SubscribeBooksListResponse(fn func(msg BooksListResp
 		for open := true; open; {
 			um, open = <-msgs
 
-			err := json.Unmarshal(um.Payload, &msg)
+			err := json.Unmarshal(um.Payload, &msg.Payload)
 			if err != nil {
 				log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
 				continue
@@ -92,11 +97,6 @@ func (cc *ClientController) UnsubscribeBooksListResponse() {
 
 	stopChan <- true
 	delete(cc.stopSubscribers, "books.list.response")
-}
-
-// Close will clean up any existing resources on the controller
-func (cc *ClientController) Close() {
-	cc.UnsubscribeAll()
 }
 
 // PublishBooksListRequest will publish messages to 'books.list.request' channel

--- a/pkg/asyncapi/specification.go
+++ b/pkg/asyncapi/specification.go
@@ -32,9 +32,9 @@ func (s Specification) ReferenceMessage(ref string) Message {
 func (s Specification) GetPublishSubscribeCount() (publishCount, subscribeCount uint) {
 	for _, c := range s.Channels {
 		if c.Publish != nil {
-			publishCount += 1
+			publishCount++
 		} else if c.Subscribe != nil {
-			subscribeCount += 1
+			subscribeCount++
 		}
 	}
 

--- a/pkg/asyncapi/specification.go
+++ b/pkg/asyncapi/specification.go
@@ -28,3 +28,15 @@ func (s Specification) ReferenceMessage(ref string) Message {
 	name := strings.Split(ref, "/")[3]
 	return s.Components.Messages[name]
 }
+
+func (s Specification) GetPublishSubscribeCount() (publishCount, subscribeCount uint) {
+	for _, c := range s.Channels {
+		if c.Publish != nil {
+			publishCount += 1
+		} else if c.Subscribe != nil {
+			subscribeCount += 1
+		}
+	}
+
+	return publishCount, subscribeCount
+}

--- a/pkg/codegen/generators/app_controller.go
+++ b/pkg/codegen/generators/app_controller.go
@@ -12,12 +12,21 @@ type AppControllerGenerator struct {
 	// CorrelationIDLocation will indicate where the correlation id is
 	// According to this: https://www.asyncapi.com/docs/reference/specification/v2.5.0#correlationIDObject
 	CorrelationIDLocation map[string]string
+
+	PublishCount   uint
+	SubscribeCount uint
 }
 
 func NewAppControllerGenerator(spec asyncapi.Specification) AppControllerGenerator {
+	publishCount, subscribeCount := spec.GetPublishSubscribeCount()
+
 	return AppControllerGenerator{
-		Specification:         spec,
+		Specification: spec,
+
 		CorrelationIDLocation: getCorrelationIDsLocationsByChannel(spec),
+
+		PublishCount:   publishCount,
+		SubscribeCount: subscribeCount,
 	}
 }
 

--- a/pkg/codegen/generators/app_subscriber.go
+++ b/pkg/codegen/generators/app_subscriber.go
@@ -12,12 +12,17 @@ type AppSubscriberGenerator struct {
 	// CorrelationIDLocation will indicate where the correlation id is
 	// According to this: https://www.asyncapi.com/docs/reference/specification/v2.5.0#correlationIDObject
 	CorrelationIDLocation map[string]string
+
+	PublishCount uint
 }
 
 func NewAppSubscriberGenerator(spec asyncapi.Specification) AppSubscriberGenerator {
+	publishCount, _ := spec.GetPublishSubscribeCount()
+
 	return AppSubscriberGenerator{
 		Specification:         spec,
 		CorrelationIDLocation: getCorrelationIDsLocationsByChannel(spec),
+		PublishCount:          publishCount,
 	}
 }
 

--- a/pkg/codegen/generators/client_controller.go
+++ b/pkg/codegen/generators/client_controller.go
@@ -12,12 +12,21 @@ type ClientControllerGenerator struct {
 	// CorrelationIDLocation will indicate where the correlation id is
 	// According to this: https://www.asyncapi.com/docs/reference/specification/v2.5.0#correlationIDObject
 	CorrelationIDLocation map[string]string
+
+	PublishCount   uint
+	SubscribeCount uint
 }
 
 func NewClientControllerGenerator(spec asyncapi.Specification) ClientControllerGenerator {
+	publishCount, subscribeCount := spec.GetPublishSubscribeCount()
+
 	return ClientControllerGenerator{
-		Specification:         spec,
+		Specification: spec,
+
 		CorrelationIDLocation: getCorrelationIDsLocationsByChannel(spec),
+
+		PublishCount:   publishCount,
+		SubscribeCount: subscribeCount,
 	}
 }
 

--- a/pkg/codegen/generators/client_subscriber.go
+++ b/pkg/codegen/generators/client_subscriber.go
@@ -12,12 +12,17 @@ type ClientSubscriberGenerator struct {
 	// CorrelationIDLocation will indicate where the correlation id is
 	// According to this: https://www.asyncapi.com/docs/reference/specification/v2.5.0#correlationIDObject
 	CorrelationIDLocation map[string]string
+
+	SubscribeCount uint
 }
 
 func NewClientSubscriberGenerator(spec asyncapi.Specification) ClientSubscriberGenerator {
+	_, subscribeCount := spec.GetPublishSubscribeCount()
+
 	return ClientSubscriberGenerator{
 		Specification:         spec,
 		CorrelationIDLocation: getCorrelationIDsLocationsByChannel(spec),
+		SubscribeCount:        subscribeCount,
 	}
 }
 

--- a/pkg/codegen/generators/templates/app/controller.tmpl
+++ b/pkg/codegen/generators/templates/app/controller.tmpl
@@ -15,6 +15,7 @@ func NewAppController(bs BrokerController) *AppController {
     }
 }
 
+{{if .PublishCount -}}
 // SubscribeAll will subscribe to channels on which the app is expecting messages
 func (ac *AppController) SubscribeAll(as AppSubscriber) error {
     // TODO: Check that as is not nil
@@ -35,6 +36,12 @@ func (ac *AppController) UnsubscribeAll() {
     {{end -}}{{- end -}}
 }
 
+// Close will clean up any existing resources on the controller
+func (ac *AppController) Close() {
+    ac.UnsubscribeAll()
+}
+{{- end}}
+
 {{range  $key, $value := .Specification.Channels -}}
 {{- if $value.Publish -}}
 // Subscribe{{namify $key}} will subscribe to new messages from '{{$key}}' channel
@@ -53,7 +60,7 @@ func (ac *AppController) Subscribe{{namify $key}}(fn func (msg {{channelToMessag
         for open := true; open; {
             um, open = <-msgs
 
-            err := json.Unmarshal(um.Payload, &msg)
+            err := json.Unmarshal(um.Payload, &msg.Payload)
             if err != nil {
                 log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
                 continue
@@ -83,11 +90,6 @@ func (ac *AppController) Unsubscribe{{namify $key}}() {
 }
 {{- end -}}
 {{- end}}
-
-// Close will clean up any existing resources on the controller
-func (ac *AppController) Close() {
-    ac.UnsubscribeAll()
-}
 
 {{- range  $key, $value := .Specification.Channels}}
 {{if $value.Subscribe}}

--- a/pkg/codegen/generators/templates/app/subscriber.tmpl
+++ b/pkg/codegen/generators/templates/app/subscriber.tmpl
@@ -1,3 +1,4 @@
+{{if .PublishCount -}}
 // AppSubscriber represents all application handlers that are expecting messages from clients
 type AppSubscriber interface {
 {{- range  $key, $value := .Specification.Channels}}
@@ -7,3 +8,4 @@ type AppSubscriber interface {
 {{end -}}
 {{end}}
 }
+{{- end}}

--- a/pkg/codegen/generators/templates/client/controller.tmpl
+++ b/pkg/codegen/generators/templates/client/controller.tmpl
@@ -15,6 +15,7 @@ func NewClientController(bs BrokerController) *ClientController {
     }
 }
 
+{{if .SubscribeCount -}}
 // SubscribeAll will subscribe to channels on which the client is expecting messages
 func (cc *ClientController) SubscribeAll(cs ClientSubscriber) error {
     // TODO: Check that cs is not nil
@@ -35,6 +36,12 @@ func (cc *ClientController) UnsubscribeAll() {
     {{end -}}{{- end -}}
 }
 
+// Close will clean up any existing resources on the controller
+func (cc *ClientController) Close() {
+    cc.UnsubscribeAll()
+}
+{{- end}}
+
 {{range  $key, $value := .Specification.Channels -}}
 {{- if $value.Subscribe}}
 // Subscribe{{namify $key}} will subscribe to new messages from '{{$key}}' channel
@@ -53,7 +60,7 @@ func (cc *ClientController) Subscribe{{namify $key}}(fn func (msg {{channelToMes
         for open := true; open; {
             um, open = <-msgs
 
-            err := json.Unmarshal(um.Payload, &msg)
+            err := json.Unmarshal(um.Payload, &msg.Payload)
             if err != nil {
                 log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
                 continue
@@ -83,11 +90,6 @@ func (cc *ClientController) Unsubscribe{{namify $key}}() {
 }
 {{- end -}}
 {{- end}}
-
-// Close will clean up any existing resources on the controller
-func (cc *ClientController) Close() {
-    cc.UnsubscribeAll()
-}
 
 {{- range  $key, $value := .Specification.Channels}}
 {{if $value.Publish}}

--- a/pkg/codegen/generators/templates/client/subscriber.tmpl
+++ b/pkg/codegen/generators/templates/client/subscriber.tmpl
@@ -1,3 +1,4 @@
+{{if .SubscribeCount -}}
 // ClientSubscriber represents all application handlers that are expecting messages from application
 type ClientSubscriber interface {
 {{- range  $key, $value := .Specification.Channels}}
@@ -7,3 +8,4 @@ type ClientSubscriber interface {
 {{end -}}
 {{end}}
 }
+{{- end}}

--- a/test/data/full/full.expected.go
+++ b/test/data/full/full.expected.go
@@ -56,6 +56,11 @@ func (ac *AppController) UnsubscribeAll() {
 	ac.UnsubscribeUserModify()
 }
 
+// Close will clean up any existing resources on the controller
+func (ac *AppController) Close() {
+	ac.UnsubscribeAll()
+}
+
 // SubscribeUserDelete will subscribe to new messages from 'user/delete' channel
 func (ac *AppController) SubscribeUserDelete(fn func(msg UserDeleteMessage)) error {
 	// Subscribe to broker channel
@@ -75,7 +80,7 @@ func (ac *AppController) SubscribeUserDelete(fn func(msg UserDeleteMessage)) err
 		for open := true; open; {
 			um, open = <-msgs
 
-			err := json.Unmarshal(um.Payload, &msg)
+			err := json.Unmarshal(um.Payload, &msg.Payload)
 			if err != nil {
 				log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
 				continue
@@ -118,7 +123,7 @@ func (ac *AppController) SubscribeUserModify(fn func(msg UserModifyExtraWordingM
 		for open := true; open; {
 			um, open = <-msgs
 
-			err := json.Unmarshal(um.Payload, &msg)
+			err := json.Unmarshal(um.Payload, &msg.Payload)
 			if err != nil {
 				log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
 				continue
@@ -145,11 +150,6 @@ func (ac *AppController) UnsubscribeUserModify() {
 
 	stopChan <- true
 	delete(ac.stopSubscribers, "user/modify")
-}
-
-// Close will clean up any existing resources on the controller
-func (ac *AppController) Close() {
-	ac.UnsubscribeAll()
 }
 
 // PublishUserSignedin will publish messages to 'user/signedin' channel
@@ -252,6 +252,11 @@ func (cc *ClientController) UnsubscribeAll() {
 	cc.UnsubscribeUserSignedup()
 }
 
+// Close will clean up any existing resources on the controller
+func (cc *ClientController) Close() {
+	cc.UnsubscribeAll()
+}
+
 // SubscribeUserSignedin will subscribe to new messages from 'user/signedin' channel
 func (cc *ClientController) SubscribeUserSignedin(fn func(msg UserSignedinMessage)) error {
 	// Subscribe to broker channel
@@ -271,7 +276,7 @@ func (cc *ClientController) SubscribeUserSignedin(fn func(msg UserSignedinMessag
 		for open := true; open; {
 			um, open = <-msgs
 
-			err := json.Unmarshal(um.Payload, &msg)
+			err := json.Unmarshal(um.Payload, &msg.Payload)
 			if err != nil {
 				log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
 				continue
@@ -316,7 +321,7 @@ func (cc *ClientController) SubscribeUserSignedup(fn func(msg UserSignedUpExtraW
 		for open := true; open; {
 			um, open = <-msgs
 
-			err := json.Unmarshal(um.Payload, &msg)
+			err := json.Unmarshal(um.Payload, &msg.Payload)
 			if err != nil {
 				log.Println("an error happened when receiving an event:", err) // TODO: add proper error handling
 				continue
@@ -343,11 +348,6 @@ func (cc *ClientController) UnsubscribeUserSignedup() {
 
 	stopChan <- true
 	delete(cc.stopSubscribers, "user/signedup")
-}
-
-// Close will clean up any existing resources on the controller
-func (cc *ClientController) Close() {
-	cc.UnsubscribeAll()
 }
 
 // PublishUserDelete will publish messages to 'user/delete' channel


### PR DESCRIPTION
When you generate an asyncapi file with no publish or subscribe channel, then one side of the client/app won't have subscription.

This commit removes the useless code associated.