### PR TITLE
Add subscription cancellation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ func (ac *AppController) UnsubscribeAll()
 //
 // You just have to give a function that match the signature of the callback and
 // then process the received message.
-func (ac *AppController) SubscribeHello(fn func(msg HelloMessage)) error
+func (ac *AppController) SubscribeHello(fn func(msg HelloMessage, done bool)) error
 
 // UnsubscribeHello will unsubscribe only the subscription on the "hello" channel.
 // It should be only used when wanting specifically that, otherwise the clean up
@@ -144,7 +144,7 @@ defer ctrl.Close()
 
 // Subscribe to HelloWorld messages
 log.Println("Subscribe to hello world...")
-ctrl.SubscribeHello(func(msg generated.HelloMessage) {
+ctrl.SubscribeHello(func(msg generated.HelloMessage, _ bool) {
   log.Println("Received message:", msg.Payload)
 })
 
@@ -178,7 +178,7 @@ func (cc *ClientController) Close()
 
 // PublishHello will publish a hello world message on the "hello" channel as
 // specified in the AsyncAPI specification.
-func (cc *ClientController) PublishHello(msg HelloMessage) error
+func (cc *ClientController) PublishHello(msg HelloMessage, done bool) error
 ```
 
 And here is an example of the client that could be written to use this generated
@@ -260,7 +260,7 @@ type ServerSubscriber struct {
 	Controller *generated.AppController
 }
 
-func (s ServerSubscriber) Ping(req generated.PingMessage) {
+func (s ServerSubscriber) Ping(req generated.PingMessage, _ bool) {
 	// Generate a pong message, set as a response of the request
 	resp := generated.NewPongMessage()
 	resp.SetAsResponseFrom(req)

--- a/examples/helloworld/app/generated/types.gen.go
+++ b/examples/helloworld/app/generated/types.gen.go
@@ -13,8 +13,8 @@ var (
 	// Generic error for AsyncAPI generated code
 	ErrAsyncAPI = errors.New("error when using AsyncAPI")
 
-	// ErrContextCancelled is given when a given context is cancelled
-	ErrContextCancelled = fmt.Errorf("%w: context cancelled", ErrAsyncAPI)
+	// ErrContextCanceled is given when a given context is canceled
+	ErrContextCanceled = fmt.Errorf("%w: context canceled", ErrAsyncAPI)
 
 	// ErrNilBrokerController is raised when a nil broker controller is user
 	ErrNilBrokerController = fmt.Errorf("%w: nil broker controller has been used", ErrAsyncAPI)
@@ -28,6 +28,9 @@ var (
 	// ErrAlreadySubscribedChannel is raised when a subscription is done twice
 	// or more without unsubscribing
 	ErrAlreadySubscribedChannel = fmt.Errorf("%w: the channel has already been subscribed", ErrAsyncAPI)
+
+	// ErrSubscriptionCanceled is raised when expecting something and the subscription has been canceled before it happens
+	ErrSubscriptionCanceled = fmt.Errorf("%w: the subscription has been canceled", ErrAsyncAPI)
 )
 
 type MessageWithCorrelationID interface {

--- a/examples/helloworld/app/main.go
+++ b/examples/helloworld/app/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	// Subscribe to HelloWorld messages
 	log.Println("Subscribe to hello world...")
-	ctrl.SubscribeHello(func(msg generated.HelloMessage) {
+	ctrl.SubscribeHello(func(msg generated.HelloMessage, _ bool) {
 		log.Println("Received message:", msg.Payload)
 	})
 

--- a/examples/helloworld/client/generated/types.gen.go
+++ b/examples/helloworld/client/generated/types.gen.go
@@ -13,8 +13,8 @@ var (
 	// Generic error for AsyncAPI generated code
 	ErrAsyncAPI = errors.New("error when using AsyncAPI")
 
-	// ErrContextCancelled is given when a given context is cancelled
-	ErrContextCancelled = fmt.Errorf("%w: context cancelled", ErrAsyncAPI)
+	// ErrContextCanceled is given when a given context is canceled
+	ErrContextCanceled = fmt.Errorf("%w: context canceled", ErrAsyncAPI)
 
 	// ErrNilBrokerController is raised when a nil broker controller is user
 	ErrNilBrokerController = fmt.Errorf("%w: nil broker controller has been used", ErrAsyncAPI)
@@ -28,6 +28,9 @@ var (
 	// ErrAlreadySubscribedChannel is raised when a subscription is done twice
 	// or more without unsubscribing
 	ErrAlreadySubscribedChannel = fmt.Errorf("%w: the channel has already been subscribed", ErrAsyncAPI)
+
+	// ErrSubscriptionCanceled is raised when expecting something and the subscription has been canceled before it happens
+	ErrSubscriptionCanceled = fmt.Errorf("%w: the subscription has been canceled", ErrAsyncAPI)
 )
 
 type MessageWithCorrelationID interface {

--- a/examples/ping/client/generated/types.gen.go
+++ b/examples/ping/client/generated/types.gen.go
@@ -16,8 +16,8 @@ var (
 	// Generic error for AsyncAPI generated code
 	ErrAsyncAPI = errors.New("error when using AsyncAPI")
 
-	// ErrContextCancelled is given when a given context is cancelled
-	ErrContextCancelled = fmt.Errorf("%w: context cancelled", ErrAsyncAPI)
+	// ErrContextCanceled is given when a given context is canceled
+	ErrContextCanceled = fmt.Errorf("%w: context canceled", ErrAsyncAPI)
 
 	// ErrNilBrokerController is raised when a nil broker controller is user
 	ErrNilBrokerController = fmt.Errorf("%w: nil broker controller has been used", ErrAsyncAPI)
@@ -31,6 +31,9 @@ var (
 	// ErrAlreadySubscribedChannel is raised when a subscription is done twice
 	// or more without unsubscribing
 	ErrAlreadySubscribedChannel = fmt.Errorf("%w: the channel has already been subscribed", ErrAsyncAPI)
+
+	// ErrSubscriptionCanceled is raised when expecting something and the subscription has been canceled before it happens
+	ErrSubscriptionCanceled = fmt.Errorf("%w: the subscription has been canceled", ErrAsyncAPI)
 )
 
 type MessageWithCorrelationID interface {

--- a/examples/ping/docker-compose.yml
+++ b/examples/ping/docker-compose.yml
@@ -3,8 +3,8 @@ version: "3.5"
 services:
   nats:
     image: nats:alpine
-    # ports:
-    #     - 4222:4222
+    ports:
+        - 4222:4222
     networks:
       - nats-network
   server:

--- a/examples/ping/server/generated/types.gen.go
+++ b/examples/ping/server/generated/types.gen.go
@@ -16,8 +16,8 @@ var (
 	// Generic error for AsyncAPI generated code
 	ErrAsyncAPI = errors.New("error when using AsyncAPI")
 
-	// ErrContextCancelled is given when a given context is cancelled
-	ErrContextCancelled = fmt.Errorf("%w: context cancelled", ErrAsyncAPI)
+	// ErrContextCanceled is given when a given context is canceled
+	ErrContextCanceled = fmt.Errorf("%w: context canceled", ErrAsyncAPI)
 
 	// ErrNilBrokerController is raised when a nil broker controller is user
 	ErrNilBrokerController = fmt.Errorf("%w: nil broker controller has been used", ErrAsyncAPI)
@@ -31,6 +31,9 @@ var (
 	// ErrAlreadySubscribedChannel is raised when a subscription is done twice
 	// or more without unsubscribing
 	ErrAlreadySubscribedChannel = fmt.Errorf("%w: the channel has already been subscribed", ErrAsyncAPI)
+
+	// ErrSubscriptionCanceled is raised when expecting something and the subscription has been canceled before it happens
+	ErrSubscriptionCanceled = fmt.Errorf("%w: the subscription has been canceled", ErrAsyncAPI)
 )
 
 type MessageWithCorrelationID interface {

--- a/examples/ping/server/main.go
+++ b/examples/ping/server/main.go
@@ -26,7 +26,7 @@ type ServerSubscriber struct {
 	Controller *generated.AppController
 }
 
-func (s ServerSubscriber) Ping(req generated.PingMessage) {
+func (s ServerSubscriber) Ping(req generated.PingMessage, _ bool) {
 	log.Println("Received a ping request")
 
 	// Generate a pong message, set as a response of the request

--- a/pkg/codegen/generators/templates/controller.tmpl
+++ b/pkg/codegen/generators/templates/controller.tmpl
@@ -70,11 +70,15 @@ func (c *{{ .Prefix }}Controller) UnsubscribeAll() {
 {{- end}}
 
 {{range  $key, $value := .SubscribeChannels -}}
-// Subscribe{{namify $key}} will subscribe to new messages from '{{$key}}' channel
+// Subscribe{{namify $key}} will subscribe to new messages from '{{$key}}' channel.
+//
+// Callback function 'fn' will be called each time a new message is received.
+// The 'done' argument indicates when the subscription is canceled and can be
+// used to clean up resources.
 {{- if .Parameters}}
-func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(params {{namify $key}}Parameters, fn func (msg {{channelToMessageTypeName $value}})) error {
+func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(params {{namify $key}}Parameters, fn func (msg {{channelToMessageTypeName $value}}, done bool)) error {
 {{- else}}
-func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(fn func (msg {{channelToMessageTypeName $value}})) error {
+func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(fn func (msg {{channelToMessageTypeName $value}}, done bool)) error {
 {{- end }}
     // Get channel path
     path := {{ generateChannelPath $value }}
@@ -93,12 +97,24 @@ func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(fn func (msg {{chann
 
     // Asynchronously listen to new messages and pass them to app subscriber
     go func() {
-        for um, open := <-msgs; open; um, open = <-msgs{
+        for {
+            // Wait for next message
+            um, open := <-msgs
+
+            // Process message
             msg, err := new{{channelToMessageTypeName $value}}FromUniversalMessage(um)
             if err != nil {
                 c.handleError(path, err)
-            } else {
-                fn(msg)
+            }
+            
+            // Send info if message is correct or susbcription is closed
+            if err == nil || !open {
+                fn(msg, !open)
+            }
+
+            // If subscription is closed, then exit the function
+            if !open {
+                return
             }
         }
     } ()
@@ -196,19 +212,23 @@ func (cc *ClientController) WaitFor{{namify $key}}(ctx context.Context, msg Mess
     // Wait for corresponding response
     for {
         select {
-        case um := <-msgs:
+        case um, open := <-msgs:
+            // Get new message
             msg, err := new{{channelToMessageTypeName $value}}FromUniversalMessage(um)
             if err != nil {
                 cc.handleError(path, err)
-                continue
             }
 
-            if {{if not $value.Subscribe.Message.CorrelationIDRequired}}msg.{{referenceToStructAttributePath $value.Subscribe.Message.CorrelationIDLocation}} != nil && {{end -}}
+            // If valid message with corresponding correlation ID, return message
+            if err == nil &&
+                {{if not $value.Subscribe.Message.CorrelationIDRequired}}msg.{{referenceToStructAttributePath $value.Subscribe.Message.CorrelationIDLocation}} != nil && {{end -}}
                 msg.CorrelationID() == {{if not $value.Subscribe.Message.CorrelationIDRequired}}*{{end}}msg.{{referenceToStructAttributePath $value.Subscribe.Message.CorrelationIDLocation}} {
                 return msg, nil
+            } else if !open { // If message is invalid or not corresponding and the subscription is closed, then return error
+                return {{channelToMessageTypeName $value}}{}, ErrSubscriptionCanceled
             }
-        case <-ctx.Done(): // TODO: make it consumable between two call
-            return {{channelToMessageTypeName $value}}{}, ErrContextCancelled
+        case <-ctx.Done(): // Return error if context is done
+            return {{channelToMessageTypeName $value}}{}, ErrContextCanceled
         }
     }
 }

--- a/pkg/codegen/generators/templates/parameters.tmpl
+++ b/pkg/codegen/generators/templates/parameters.tmpl
@@ -1,11 +1,11 @@
 {{define "parameters"}}
 // {{ namify .Name }}Parameters represents {{ namify .Name }} channel parameters
 type {{ namify .Name }}Parameters struct {
-{{range $key, $value := .Parameters -}}
+{{- range $key, $value := .Parameters}}
     {{- if $value.Description}}
     // Description: {{$value.Description}}
     {{end}}
-    {{ namify $key }} string
+    {{- namify $key }} string
 {{end -}}
 }
 {{end}}

--- a/pkg/codegen/generators/templates/subscriber.tmpl
+++ b/pkg/codegen/generators/templates/subscriber.tmpl
@@ -3,7 +3,7 @@
 type {{ .Prefix }}Subscriber interface {
 {{- range  $key, $value := .Channels}}
     // {{namify $key}}
-    {{namify $key}}(msg {{channelToMessageTypeName $value}})
+    {{namify $key}}(msg {{channelToMessageTypeName $value}}, done bool)
 {{end}}
 }
 {{- end}}

--- a/pkg/codegen/generators/templates/types.tmpl
+++ b/pkg/codegen/generators/templates/types.tmpl
@@ -2,8 +2,8 @@ var (
     // Generic error for AsyncAPI generated code
     ErrAsyncAPI = errors.New("error when using AsyncAPI")
 
-    // ErrContextCancelled is given when a given context is cancelled
-    ErrContextCancelled = fmt.Errorf("%w: context cancelled", ErrAsyncAPI)
+    // ErrContextCanceled is given when a given context is canceled
+    ErrContextCanceled = fmt.Errorf("%w: context canceled", ErrAsyncAPI)
 
     // ErrNilBrokerController is raised when a nil broker controller is user
     ErrNilBrokerController = fmt.Errorf("%w: nil broker controller has been used", ErrAsyncAPI)
@@ -17,6 +17,9 @@ var (
     // ErrAlreadySubscribedChannel is raised when a subscription is done twice
     // or more without unsubscribing
     ErrAlreadySubscribedChannel = fmt.Errorf("%w: the channel has already been subscribed", ErrAsyncAPI)
+
+    // ErrSubscriptionCanceled is raised when expecting something and the subscription has been canceled before it happens
+    ErrSubscriptionCanceled = fmt.Errorf("%w: the subscription has been canceled", ErrAsyncAPI)
 )
 
 type MessageWithCorrelationID interface {


### PR DESCRIPTION
When using a callback or a loop over a subscription, there is no mean to know when the latter is cancelled and potentially clean up resources or throw an error.

This commit introduces this information as a boolean in argument of callback in SubscribeXXX and as an error in WaitForXXX.