### PR TITLE
Fix double Close() panic

### DIFF
--- a/examples/helloworld/app/generated/app.gen.go
+++ b/examples/helloworld/app/generated/app.gen.go
@@ -42,8 +42,13 @@ func (c AppController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *AppController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.

--- a/examples/helloworld/client/generated/client.gen.go
+++ b/examples/helloworld/client/generated/client.gen.go
@@ -32,7 +32,12 @@ func (c ClientController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *ClientController) Close() {
-	close(c.errChan)
+	// Unsubscribing remaining channels
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // PublishHello will publish messages to 'hello' channel

--- a/examples/ping/client/generated/client.gen.go
+++ b/examples/ping/client/generated/client.gen.go
@@ -43,8 +43,13 @@ func (c ClientController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *ClientController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.

--- a/examples/ping/server/generated/app.gen.go
+++ b/examples/ping/server/generated/app.gen.go
@@ -42,8 +42,13 @@ func (c AppController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *AppController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.

--- a/pkg/codegen/generators/templates/controller.tmpl
+++ b/pkg/codegen/generators/templates/controller.tmpl
@@ -27,10 +27,16 @@ func (c {{ .Prefix }}Controller) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *{{ .Prefix }}Controller) Close() {
+    // Unsubscribing remaining channels
 {{if .MethodCount -}}
     c.UnsubscribeAll()
 {{end -}}
-    close(c.errChan)
+
+    // Close the channel and put its reference to nil, if not already closed (= being nil)
+    if c.errChan != nil {
+        close(c.errChan)
+        c.errChan = nil
+    }
 }
 
 {{if .MethodCount -}}

--- a/test/official/expected/anyof/anyof.expected.go
+++ b/test/official/expected/anyof/anyof.expected.go
@@ -44,8 +44,13 @@ func (c AppController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *AppController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -185,7 +190,12 @@ func (c ClientController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *ClientController) Close() {
-	close(c.errChan)
+	// Unsubscribing remaining channels
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // PublishTest will publish messages to 'test' channel

--- a/test/official/expected/correlation-id/correlation_id.expected.go
+++ b/test/official/expected/correlation-id/correlation_id.expected.go
@@ -47,8 +47,13 @@ func (c AppController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *AppController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -202,8 +207,13 @@ func (c ClientController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *ClientController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.

--- a/test/official/expected/oneof/oneof.expected.go
+++ b/test/official/expected/oneof/oneof.expected.go
@@ -44,8 +44,13 @@ func (c AppController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *AppController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -204,8 +209,13 @@ func (c ClientController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *ClientController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.

--- a/test/official/expected/rpc-server/rpc-server.expected.go
+++ b/test/official/expected/rpc-server/rpc-server.expected.go
@@ -47,8 +47,13 @@ func (c AppController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *AppController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -207,8 +212,13 @@ func (c ClientController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *ClientController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.

--- a/test/official/expected/simple/simple.expected.go
+++ b/test/official/expected/simple/simple.expected.go
@@ -38,7 +38,12 @@ func (c AppController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *AppController) Close() {
-	close(c.errChan)
+	// Unsubscribing remaining channels
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // PublishUserSignedup will publish messages to 'user/signedup' channel
@@ -104,8 +109,13 @@ func (c ClientController) Errors() <-chan Error {
 
 // Close will clean up any existing resources on the controller
 func (c *ClientController) Close() {
+	// Unsubscribing remaining channels
 	c.UnsubscribeAll()
-	close(c.errChan)
+	// Close the channel and put its reference to nil, if not already closed (= being nil)
+	if c.errChan != nil {
+		close(c.errChan)
+		c.errChan = nil
+	}
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.


### PR DESCRIPTION
When using the App controller or the Client controller, if the Close() function is called twice or more, then the second call will trigger a panic as the error channel is already closed.

This commit puts the channel at nil and checks if it wasn't already closed before closing it.