### PR TITLE
Change generated file permission to 0644

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -87,7 +87,7 @@ func (cg CodeGen) Generate(opt Options) error {
 		fileContent = []byte(content)
 	}
 
-	return os.WriteFile(opt.OutputPath, fileContent, 0755)
+	return os.WriteFile(opt.OutputPath, fileContent, 0644)
 }
 
 func (cg CodeGen) generateImports(opts Options) (string, error) {


### PR DESCRIPTION
The *.go source files are not meant to be executable, so the executable permission of the generated file is likely not needed.

Fixes https://github.com/lerenn/asyncapi-codegen/issues/50.