### PR TITLE
fix: headers from schema reference support

### DIFF
--- a/pkg/codegen/generators/templates/message.tmpl
+++ b/pkg/codegen/generators/templates/message.tmpl
@@ -44,7 +44,11 @@ func new{{namify .Name}}MessageFromBrokerMessage(bMsg extensions.BrokerMessage) 
     // Get each headers from broker message
     for k, v := range bMsg.Headers {
         switch {
-            {{- range  $key, $value := .Headers.Properties}}
+            {{- $headerProperties := .Headers.Properties}}
+            {{- if .Headers.Reference }}
+            {{- $headerProperties = .Headers.ReferenceTo.Properties}}
+            {{- end}}
+            {{- range  $key, $value := $headerProperties}}
             case k == "{{$key}}": // Retrieving {{namify $key}} header
                 {{- if eq $value.Type "object" }}
                     {{- if $value.IsRequired }}
@@ -57,10 +61,20 @@ func new{{namify .Name}}MessageFromBrokerMessage(bMsg extensions.BrokerMessage) 
                     }
                 {{- else }}
                     {{- if $value.IsRequired }}
+                    {{- if or (eq $value.Format "date") (eq $value.Format "date-time")}}
+                    t, _ := time.Parse(time.RFC3339, string(v))
+                    msg.Headers.{{ namify $key}} = t
+                    {{- else}}
                     msg.Headers.{{ namify $key}} = {{$value.Type}}(v)
+                    {{- end}}
+                    {{- else}}
+                    {{- if or (eq $value.Format "date") (eq $value.Format "date-time")}}
+                    t, _ := time.Parse(time.RFC3339, string(v))
+                    msg.Headers.{{ namify $key}} = &t
                     {{- else}}
                     h := {{$value.Type}}(v)
                     msg.Headers.{{ namify $key}} = &h
+                    {{- end}}
                     {{- end}}
                 {{- end}}
             {{- end}}


### PR DESCRIPTION
### Description

While testing the headers support (client), I noticed that it was failing when headers properties where defined as a reference to a schema instead of a plain list of properties.
Here is an example of a contract where the generation is not working as expected:
```
asyncapi: 2.6.0
info:
  title: test
  version: 1.0.0
  description: test
channels:
  channel:
    description: channel
    publish:
      message:
        $ref: '#/components/messages/Message'
components:
  messages:
    Message:
      description: test message
      headers:
        $ref: '#/components/schemas/HeaderSchema'      
      payload:        
        oneOf:
          - $ref: '#/components/schemas/TestSchema'
  schemas:
    HeaderSchema:
      type: object
      description: header
      required:
        - version
        - dateTime
      properties:
        version:
          description: Schema version
          type: string
          example: '1.0.1'
        dateTime:
            description: Date in UTC format "YYYY-MM-DDThh:mm:ss.sZ".
            example: '2023-09-15T20:15:58.0Z'
            type: string
            format: date-time
    TestSchema:
      type: object
      required:
        - obj1
      properties:
        obj1:
          type: object
          required:
            - referenceId
          properties:
            referenceId:
              description: reference ID.
              type: string
              example: "1234567890123456"
````
There was also an issue supporting the `date` and `date-time` format as it was considered as a regular string.

The fix I've made might not cover all test cases. It was sufficient enough to deal with our contract definition and
seems to bring no regression on existing use cases.

Since there is no tests structure yet (TBD as I can see), I did not write any tests for these 2 issues.

Let me know if you would like me to write some tests if you already have an idea on how you want to organize your repo
to support unit testing of the generation part.

Thank you!
