### PR TITLE
Remove unecessary parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ comments:
 
 ```go
 // AppController is the struct that you will need in order to interact with the
-// event broker from the application side. You will generate this with the 
+// event broker from the application side. You will generate this with the
 // NewAppController function below.
 type AppController struct
 
@@ -142,7 +142,7 @@ func (ac *AppController) Close(ctx context.Context)
 
 // SubscribeAll will subscribe to all channel that the application should listen to.
 //
-// In order to use it, you'll have to implement the AppSubscriber interface and 
+// In order to use it, you'll have to implement the AppSubscriber interface and
 // pass it as an argument to this function. Thus, the subscription will automatically
 // call the corresponding function when it will receive a message.
 //
@@ -165,7 +165,7 @@ func (ac *AppController) UnsubscribeAll(ctx context.Context)
 //
 // The subscription will be canceled if the context is canceled, if the subscription
 // is explicitely unsubscribed or if the controller is closed
-func (ac *AppController) SubscribeHello(ctx context.Context, fn func(msg HelloMessage, done bool)) error
+func (ac *AppController) SubscribeHello(ctx context.Context, fn func(msg HelloMessage)) error
 
 // UnsubscribeHello will unsubscribe only the subscription on the "hello" channel.
 // It should be only used when wanting specifically that, otherwise the clean up
@@ -190,7 +190,7 @@ func main() {
   // Subscribe to HelloWorld messages
   // Note: it will indefinitely wait for messages as context has no timeout
   log.Println("Subscribe to hello world...")
-  ctrl.SubscribeHello(context.Background(), func(_ context.Context, msg HelloMessage, _ bool) {
+  ctrl.SubscribeHello(context.Background(), func(_ context.Context, msg HelloMessage) {
     log.Println("Received message:", msg.Payload)
   })
 
@@ -206,7 +206,7 @@ comments:
 
 ```go
 // UserController is the struct that you will need in order to interact with the
-// event broker from the user side. You will generate this with the 
+// event broker from the user side. You will generate this with the
 // NewUserController function below.
 type UserController struct
 
@@ -262,7 +262,7 @@ type HelloMessage struct {
 
 ### Request/Response example
 
-This example will use a `ping` example that you can find 
+This example will use a `ping` example that you can find
 [here](./examples/ping/asyncapi.yaml).
 
 > The code for this example have already been generated and can be
@@ -280,7 +280,7 @@ asyncapi-codegen -i examples/ping/asyncapi.yaml -p main -o ./ping.gen.go
 ```
 
 We can then go through the possible application and user implementations that
-use `ping.gen.go`. 
+use `ping.gen.go`.
 
 #### Application
 
@@ -289,7 +289,7 @@ type Subscriber struct {
 	Controller *AppController
 }
 
-func (s Subscriber) Ping(req PingMessage, _ bool) {
+func (s Subscriber) Ping(req PingMessage) {
 	// Generate a pong message, set as a response of the request
 	resp := NewPongMessage()
 	resp.SetAsResponseFrom(&req)
@@ -335,7 +335,7 @@ publicationFunc := func(ctx context.Context) error {
 // The following function will subscribe to the 'pong' channel, execute the publication
 // function and wait for a response. The response will be detected through its
 // correlation ID.
-// 
+//
 // This function is available only if the 'correlationId' field has been filled
 // for any channel in the AsyncAPI specification. You will then be able to use it
 // with the form WaitForXXX where XXX is the channel name.
@@ -613,10 +613,10 @@ AsyncAPI specifications, you can use the `versioning` package:
 ```golang
 
 import (
-	"github.com/lerenn/asyncapi-codegen/pkg/extensions/brokers/nats"
+  "github.com/lerenn/asyncapi-codegen/pkg/extensions/brokers/nats"
   "github.com/lerenn/asyncapi-codegen/pkg/extensions/versioning"
-	v1 "path/to/asyncapi/spec/version/1"
-	v2 "path/to/asyncapi/spec/version/2"
+  v1 "path/to/asyncapi/spec/version/1"
+  v2 "path/to/asyncapi/spec/version/2"
 )
 
 func main() {
@@ -641,12 +641,12 @@ func main() {
 Then you can use each application independently:
 
 ```golang
-err := appV1.SubscribeHello(context.Background(), func(_ context.Context, msg v1.HelloMessage, _ bool) {
-		// Stuff for version 1
+err := appV1.SubscribeHello(context.Background(), func(ctx context.Context, msg v1.HelloMessage) {
+  // Stuff for version 1
 })
 
-err := appV2.SubscribeHello(context.Background(), func(_ context.Context, msg v2.HelloMessage, _ bool) {
-		// Stuff for version 2
+err := appV2.SubscribeHello(context.Background(), func(ctx context.Context, msg v2.HelloMessage) {
+  // Stuff for version 2
 })
 ```
 
@@ -654,7 +654,7 @@ That way, you can support multiple different versions with the same broker.
 
 #### Version tagging
 
-**Important**: this feature will add an `application-version` header to each
+The versioning feature will add an `application-version` header to each
 message in order to have the correct version of the application on each of
 them.
 

--- a/examples/helloworld/nats/app/main.go
+++ b/examples/helloworld/nats/app/main.go
@@ -25,7 +25,7 @@ func main() {
 	// Subscribe to HelloWorld messages
 	// Note: it will indefinitely wait for messages as context has no timeout
 	log.Println("Subscribe to hello world...")
-	ctrl.SubscribeHello(context.Background(), func(_ context.Context, msg HelloMessage, _ bool) {
+	ctrl.SubscribeHello(context.Background(), func(_ context.Context, msg HelloMessage) {
 		log.Println("Received message:", msg.Payload)
 	})
 

--- a/examples/ping/kafka/app/main.go
+++ b/examples/ping/kafka/app/main.go
@@ -17,7 +17,7 @@ type Subscriber struct {
 	Controller *AppController
 }
 
-func (s Subscriber) Ping(ctx context.Context, req PingMessage, _ bool) {
+func (s Subscriber) Ping(ctx context.Context, req PingMessage) {
 	// Generate a pong message, set as a response of the request
 	resp := NewPongMessage()
 	resp.SetAsResponseFrom(&req)

--- a/examples/ping/nats/app/main.go
+++ b/examples/ping/nats/app/main.go
@@ -17,7 +17,7 @@ type ServerSubscriber struct {
 	Controller *AppController
 }
 
-func (s ServerSubscriber) Ping(ctx context.Context, req PingMessage, _ bool) {
+func (s ServerSubscriber) Ping(ctx context.Context, req PingMessage) {
 	// Generate a pong message, set as a response of the request
 	resp := NewPongMessage()
 	resp.SetAsResponseFrom(&req)

--- a/pkg/codegen/generators/templates/controller.tmpl
+++ b/pkg/codegen/generators/templates/controller.tmpl
@@ -117,15 +117,16 @@ func (c *{{ .Prefix }}Controller) UnsubscribeAll(ctx context.Context) {
 // The 'done' argument indicates when the subscription is canceled and can be
 // used to clean up resources.
 {{- if .Parameters}}
-func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(ctx context.Context, params {{namify $key}}Parameters, fn func (ctx context.Context, msg {{channelToMessageTypeName $value}}, done bool)) error {
+func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(ctx context.Context, params {{namify $key}}Parameters, fn func (ctx context.Context, msg {{channelToMessageTypeName $value}})) error {
 {{- else}}
-func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(ctx context.Context, fn func (ctx context.Context, msg {{channelToMessageTypeName $value}}, done bool)) error {
+func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(ctx context.Context, fn func (ctx context.Context, msg {{channelToMessageTypeName $value}})) error {
 {{- end }}
     // Get channel path
     path := {{ generateChannelPath $value }}
 
     // Set context
     ctx = add{{ $.Prefix }}ContextValues(ctx, path)
+    ctx = context.WithValue(ctx, extensions.ContextKeyIsMessageDirection, "reception")
 
     // Check if there is already a subscription
     _, exists := c.cancelChannels[path]
@@ -149,6 +150,12 @@ func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(ctx context.Context,
             // Wait for next message
             bMsg, open := <-msgs
 
+            // If subscription is closed and there is no more message
+            // (i.e. uninitialized message), then exit the function
+            if !open && bMsg.IsUninitialized() {
+                return
+            }
+
             // Set broker message to context
             ctx = context.WithValue(ctx, extensions.ContextKeyIsBrokerMessage, bMsg)
 
@@ -159,10 +166,7 @@ func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(ctx context.Context,
             if err != nil {
                 c.logger.Error(ctx, err.Error())
             }
-
-            // Add context
             msgCtx := context.WithValue(ctx, extensions.ContextKeyIsMessage, msg)
-            msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsMessageDirection, "reception")
 
             {{if ne $value.GetChannelMessage.CorrelationIDLocation "" -}}
                 // Add correlation ID to context if it exists
@@ -171,18 +175,10 @@ func (c *{{ $.Prefix }}Controller) Subscribe{{namify $key}}(ctx context.Context,
                 }
             {{- end}}
 
-            // Process message if no error and still open
-            if err == nil && open {
-                // Execute middlewares with the callback
-                c.executeMiddlewares(msgCtx, func(ctx context.Context) {
-                    fn(ctx, msg, !open)
-                })
-            }
-
-            // If subscription is closed, then exit the function
-            if !open {
-                return
-            }
+            // Execute middlewares with the callback
+            c.executeMiddlewares(msgCtx, func(ctx context.Context) {
+                fn(ctx, msg)
+            })
         }
     } ()
 
@@ -310,30 +306,38 @@ func (cc *UserController) WaitFor{{namify $key}}(ctx context.Context, publishMsg
     for {
         select {
         case bMsg, open := <-messages:
+            // If subscription is closed and there is no more message
+            // (i.e. uninitialized message), then the subscription ended before
+            // receiving the expected message
+            if !open && bMsg.IsUninitialized() {
+                cc.logger.Error(ctx, "Channel closed before getting message")
+                return {{channelToMessageTypeName $value}}{}, extensions.ErrSubscriptionCanceled
+            }
+
             // Get new message
             msg, err := new{{channelToMessageTypeName $value}}FromBrokerMessage(bMsg)
             if err != nil {
                 cc.logger.Error(ctx, err.Error())
             }
 
-            // If valid message with corresponding correlation ID, return message
-            if err == nil && publishMsg.CorrelationID() == msg.CorrelationID() {
-                // Set context with received values
-                msgCtx := context.WithValue(ctx, extensions.ContextKeyIsMessage, msg)
-                msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsBrokerMessage, bMsg)
-                msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsMessageDirection, "reception")
-                msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsCorrelationID, publishMsg.CorrelationID())
-
-                // Execute middlewares before returning
-                cc.executeMiddlewares(msgCtx, func(_ context.Context) {
-                    /* Nothing to do more */
-                })
-
-                return msg, nil
-            } else if !open { // If message is invalid or not corresponding and the subscription is closed, then set corresponding error
-                cc.logger.Error(ctx, "Channel closed before getting message")
-                return {{channelToMessageTypeName $value}}{}, extensions.ErrSubscriptionCanceled
+            // If message doesn't have corresponding correlation ID, then continue
+            if publishMsg.CorrelationID() != msg.CorrelationID() {
+                continue
             }
+
+            // Set context with received values as it is the expected message
+            msgCtx := context.WithValue(ctx, extensions.ContextKeyIsMessage, msg)
+            msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsBrokerMessage, bMsg)
+            msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsMessageDirection, "reception")
+            msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsCorrelationID, publishMsg.CorrelationID())
+
+            // Execute middlewares before returning
+            cc.executeMiddlewares(msgCtx, func(_ context.Context) {
+                /* Nothing to do more */
+            })
+
+            // return the message to the caller
+            return msg, nil
         case <-ctx.Done(): // Set corrsponding error if context is done
             cc.logger.Error(ctx, "Context done before getting message")
             return {{channelToMessageTypeName $value}}{}, extensions.ErrContextCanceled

--- a/pkg/codegen/generators/templates/subscriber.tmpl
+++ b/pkg/codegen/generators/templates/subscriber.tmpl
@@ -3,7 +3,7 @@
 type {{ .Prefix }}Subscriber interface {
 {{- range  $key, $value := .Channels}}
     // {{namify $key}} subscribes to messages placed on the '{{ $key }}' channel
-    {{namify $key}}(ctx context.Context, msg {{channelToMessageTypeName $value}}, done bool)
+    {{namify $key}}(ctx context.Context, msg {{channelToMessageTypeName $value}})
 {{end}}
 }
 {{- end}}

--- a/pkg/extensions/broker.go
+++ b/pkg/extensions/broker.go
@@ -10,6 +10,12 @@ type BrokerMessage struct {
 	Payload []byte
 }
 
+// IsUninitialized check if the BrokerMessage is at zero value, i.e. the
+// uninitialized structure. It can be used to check that a channel is closed.
+func (bm BrokerMessage) IsUninitialized() bool {
+	return bm.Headers == nil && bm.Payload == nil
+}
+
 // BrokerController represents the functions that should be implemented to connect
 // the broker to the application or the user.
 type BrokerController interface {

--- a/pkg/extensions/broker_test.go
+++ b/pkg/extensions/broker_test.go
@@ -1,0 +1,23 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestBrokerSuite(t *testing.T) {
+	suite.Run(t, new(BrokerSuite))
+}
+
+type BrokerSuite struct {
+	suite.Suite
+}
+
+func (suite *BrokerSuite) TestIsUninitialized() {
+	suite.Require().True(BrokerMessage{}.IsUninitialized())
+
+	suite.Require().False(BrokerMessage{
+		Headers: make(map[string][]byte),
+	}.IsUninitialized())
+}

--- a/test/issues/73/suite_test.go
+++ b/test/issues/73/suite_test.go
@@ -97,14 +97,14 @@ func (suite *Suite) TestV1Reception() {
 	// Check what the app receive and translate
 	var recvMsg v1.HelloMessage
 	wg.Add(1)
-	err := suite.v1.app.SubscribeHello(context.Background(), func(_ context.Context, msg v1.HelloMessage, _ bool) {
+	err := suite.v1.app.SubscribeHello(context.Background(), func(_ context.Context, msg v1.HelloMessage) {
 		recvMsg = msg
 		wg.Done()
 	})
 	suite.Require().NoError(err)
 
 	// Check that the other app doesn't receive
-	err = suite.v2.app.SubscribeHello(context.Background(), func(_ context.Context, _ v2.HelloMessage, _ bool) {
+	err = suite.v2.app.SubscribeHello(context.Background(), func(_ context.Context, _ v2.HelloMessage) {
 		suite.Require().FailNow("this should not happen")
 	})
 	suite.Require().NoError(err)
@@ -141,7 +141,7 @@ func (suite *Suite) TestV2Reception() {
 	}
 
 	// Check that the other app doesn't receive
-	err := suite.v1.app.SubscribeHello(context.Background(), func(_ context.Context, _ v1.HelloMessage, _ bool) {
+	err := suite.v1.app.SubscribeHello(context.Background(), func(_ context.Context, _ v1.HelloMessage) {
 		suite.Require().FailNow("this should not happen")
 	})
 	suite.Require().NoError(err)
@@ -149,7 +149,7 @@ func (suite *Suite) TestV2Reception() {
 	// Check what the app receive and translate
 	var recvMsg v2.HelloMessage
 	wg.Add(1)
-	err = suite.v2.app.SubscribeHello(context.Background(), func(_ context.Context, msg v2.HelloMessage, _ bool) {
+	err = suite.v2.app.SubscribeHello(context.Background(), func(_ context.Context, msg v2.HelloMessage) {
 		recvMsg = msg
 		wg.Done()
 	})

--- a/test/issues/73/v2/asyncapi.gen.go
+++ b/test/issues/73/v2/asyncapi.gen.go
@@ -15,7 +15,7 @@ import (
 // AppSubscriber represents all handlers that are expecting messages for App
 type AppSubscriber interface {
 	// Hello subscribes to messages placed on the 'hello' channel
-	Hello(ctx context.Context, msg HelloMessage, done bool)
+	Hello(ctx context.Context, msg HelloMessage)
 }
 
 // AppController is the structure that provides publishing capabilities to the
@@ -123,12 +123,13 @@ func (c *AppController) UnsubscribeAll(ctx context.Context) {
 // Callback function 'fn' will be called each time a new message is received.
 // The 'done' argument indicates when the subscription is canceled and can be
 // used to clean up resources.
-func (c *AppController) SubscribeHello(ctx context.Context, fn func(ctx context.Context, msg HelloMessage, done bool)) error {
+func (c *AppController) SubscribeHello(ctx context.Context, fn func(ctx context.Context, msg HelloMessage)) error {
 	// Get channel path
 	path := "hello"
 
 	// Set context
 	ctx = addAppContextValues(ctx, path)
+	ctx = context.WithValue(ctx, extensions.ContextKeyIsMessageDirection, "reception")
 
 	// Check if there is already a subscription
 	_, exists := c.cancelChannels[path]
@@ -152,6 +153,12 @@ func (c *AppController) SubscribeHello(ctx context.Context, fn func(ctx context.
 			// Wait for next message
 			bMsg, open := <-msgs
 
+			// If subscription is closed and there is no more message
+			// (i.e. uninitialized message), then exit the function
+			if !open && bMsg.IsUninitialized() {
+				return
+			}
+
 			// Set broker message to context
 			ctx = context.WithValue(ctx, extensions.ContextKeyIsBrokerMessage, bMsg)
 
@@ -160,23 +167,12 @@ func (c *AppController) SubscribeHello(ctx context.Context, fn func(ctx context.
 			if err != nil {
 				c.logger.Error(ctx, err.Error())
 			}
-
-			// Add context
 			msgCtx := context.WithValue(ctx, extensions.ContextKeyIsMessage, msg)
-			msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsMessageDirection, "reception")
 
-			// Process message if no error and still open
-			if err == nil && open {
-				// Execute middlewares with the callback
-				c.executeMiddlewares(msgCtx, func(ctx context.Context) {
-					fn(ctx, msg, !open)
-				})
-			}
-
-			// If subscription is closed, then exit the function
-			if !open {
-				return
-			}
+			// Execute middlewares with the callback
+			c.executeMiddlewares(msgCtx, func(ctx context.Context) {
+				fn(ctx, msg)
+			})
 		}
 	}()
 

--- a/test/issues/74/asyncapi.gen.go
+++ b/test/issues/74/asyncapi.gen.go
@@ -15,7 +15,7 @@ import (
 // AppSubscriber represents all handlers that are expecting messages for App
 type AppSubscriber interface {
 	// TestChannel subscribes to messages placed on the 'testChannel' channel
-	TestChannel(ctx context.Context, msg TestMessage, done bool)
+	TestChannel(ctx context.Context, msg TestMessage)
 }
 
 // AppController is the structure that provides publishing capabilities to the
@@ -123,12 +123,13 @@ func (c *AppController) UnsubscribeAll(ctx context.Context) {
 // Callback function 'fn' will be called each time a new message is received.
 // The 'done' argument indicates when the subscription is canceled and can be
 // used to clean up resources.
-func (c *AppController) SubscribeTestChannel(ctx context.Context, fn func(ctx context.Context, msg TestMessage, done bool)) error {
+func (c *AppController) SubscribeTestChannel(ctx context.Context, fn func(ctx context.Context, msg TestMessage)) error {
 	// Get channel path
 	path := "testChannel"
 
 	// Set context
 	ctx = addAppContextValues(ctx, path)
+	ctx = context.WithValue(ctx, extensions.ContextKeyIsMessageDirection, "reception")
 
 	// Check if there is already a subscription
 	_, exists := c.cancelChannels[path]
@@ -152,6 +153,12 @@ func (c *AppController) SubscribeTestChannel(ctx context.Context, fn func(ctx co
 			// Wait for next message
 			bMsg, open := <-msgs
 
+			// If subscription is closed and there is no more message
+			// (i.e. uninitialized message), then exit the function
+			if !open && bMsg.IsUninitialized() {
+				return
+			}
+
 			// Set broker message to context
 			ctx = context.WithValue(ctx, extensions.ContextKeyIsBrokerMessage, bMsg)
 
@@ -160,23 +167,12 @@ func (c *AppController) SubscribeTestChannel(ctx context.Context, fn func(ctx co
 			if err != nil {
 				c.logger.Error(ctx, err.Error())
 			}
-
-			// Add context
 			msgCtx := context.WithValue(ctx, extensions.ContextKeyIsMessage, msg)
-			msgCtx = context.WithValue(msgCtx, extensions.ContextKeyIsMessageDirection, "reception")
 
-			// Process message if no error and still open
-			if err == nil && open {
-				// Execute middlewares with the callback
-				c.executeMiddlewares(msgCtx, func(ctx context.Context) {
-					fn(ctx, msg, !open)
-				})
-			}
-
-			// If subscription is closed, then exit the function
-			if !open {
-				return
-			}
+			// Execute middlewares with the callback
+			c.executeMiddlewares(msgCtx, func(ctx context.Context) {
+				fn(ctx, msg)
+			})
 		}
 	}()
 

--- a/test/issues/74/suite_test.go
+++ b/test/issues/74/suite_test.go
@@ -73,7 +73,7 @@ func (suite *Suite) TestHeaders() {
 	// Check what the app receive and translate
 	var recvMsg TestMessage
 	wg.Add(1)
-	err := suite.app.SubscribeTestChannel(context.Background(), func(_ context.Context, msg TestMessage, _ bool) {
+	err := suite.app.SubscribeTestChannel(context.Background(), func(_ context.Context, msg TestMessage) {
 		recvMsg = msg
 		wg.Done()
 	})


### PR DESCRIPTION
The `done` parameter is a relic from another time when we didn't know if the channel was properly closed.
This is not needed anymore.