### PR TITLE
Fix namify's acronyms correction

### DIFF
--- a/pkg/codegen/generators/templates/helpers.go
+++ b/pkg/codegen/generators/templates/helpers.go
@@ -31,7 +31,7 @@ func correctAcronyms(sentence string) string {
 	acronyms := []string{"ID"}
 	for _, a := range acronyms {
 		wronglyFormatedAcronym := strcase.UpperCamelCase(a)
-		re := regexp.MustCompile(fmt.Sprintf("%s[A-Z]*", wronglyFormatedAcronym))
+		re := regexp.MustCompile(fmt.Sprintf("%s[A-Z]+", wronglyFormatedAcronym))
 
 		positions := re.FindAllStringIndex(sentence, -1)
 		for _, p := range positions {

--- a/pkg/codegen/generators/templates/helpers.go
+++ b/pkg/codegen/generators/templates/helpers.go
@@ -31,7 +31,7 @@ func correctAcronyms(sentence string) string {
 	acronyms := []string{"ID"}
 	for _, a := range acronyms {
 		wronglyFormatedAcronym := strcase.UpperCamelCase(a)
-		re := regexp.MustCompile(fmt.Sprintf("%s[A-Z]+", wronglyFormatedAcronym))
+		re := regexp.MustCompile(fmt.Sprintf("%s([A-Z]+|$)", wronglyFormatedAcronym))
 
 		positions := re.FindAllStringIndex(sentence, -1)
 		for _, p := range positions {

--- a/pkg/codegen/generators/templates/helpers_test.go
+++ b/pkg/codegen/generators/templates/helpers_test.go
@@ -28,9 +28,16 @@ func (suite *HelpersSuite) TestNamify() {
 		{In: "name", Out: "Name"},
 		// Snake Case
 		{In: "eh_oh__ah", Out: "EhOhAh"},
-		// With acronym
+		// With acronym in middle
+		{In: "IdTata", Out: "IDTata"},
+		// With acronym in middle
 		{In: "TotoIdLala", Out: "TotoIDLala"},
+		// With acronym at the end
 		{In: "TotoId", Out: "TotoID"},
+		// Without acronym, but still the same letters as the acronym
+		{In: "identity", Out: "Identity"},
+		{In: "Identity", Out: "Identity"},
+		{In: "covid", Out: "Covid"},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
Got `identity`, which transformed to the `IDentity`. This fix will transform `id` to `ID` only if the next char after `id` is upper-cased