### PR TITLE
fix: let user in charge of acronyms

### DIFF
--- a/examples/ping/kafka/app/app.gen.go
+++ b/examples/ping/kafka/app/app.gen.go
@@ -315,7 +315,7 @@ type PingMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -327,7 +327,7 @@ func NewPingMessage() PingMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -343,9 +343,9 @@ func newPingMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PingMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -366,9 +366,9 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -379,8 +379,8 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PingMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -388,7 +388,7 @@ func (msg PingMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PingMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -396,7 +396,7 @@ func (msg *PingMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PingMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // PongMessage is the message expected for 'Pong' channel
@@ -404,7 +404,7 @@ type PongMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user on corresponding request
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -422,7 +422,7 @@ func NewPongMessage() PongMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -440,9 +440,9 @@ func newPongMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PongMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -466,9 +466,9 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -479,8 +479,8 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PongMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -488,7 +488,7 @@ func (msg PongMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PongMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -496,5 +496,5 @@ func (msg *PongMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PongMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }

--- a/examples/ping/kafka/user/user.gen.go
+++ b/examples/ping/kafka/user/user.gen.go
@@ -393,7 +393,7 @@ type PingMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -405,7 +405,7 @@ func NewPingMessage() PingMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -421,9 +421,9 @@ func newPingMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PingMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -444,9 +444,9 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -457,8 +457,8 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PingMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -466,7 +466,7 @@ func (msg PingMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PingMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -474,7 +474,7 @@ func (msg *PingMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PingMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // PongMessage is the message expected for 'Pong' channel
@@ -482,7 +482,7 @@ type PongMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user on corresponding request
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -500,7 +500,7 @@ func NewPongMessage() PongMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -518,9 +518,9 @@ func newPongMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PongMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -544,9 +544,9 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -557,8 +557,8 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PongMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -566,7 +566,7 @@ func (msg PongMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PongMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -574,5 +574,5 @@ func (msg *PongMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PongMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }

--- a/examples/ping/nats/app/app.gen.go
+++ b/examples/ping/nats/app/app.gen.go
@@ -315,7 +315,7 @@ type PingMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -327,7 +327,7 @@ func NewPingMessage() PingMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -343,9 +343,9 @@ func newPingMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PingMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -366,9 +366,9 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -379,8 +379,8 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PingMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -388,7 +388,7 @@ func (msg PingMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PingMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -396,7 +396,7 @@ func (msg *PingMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PingMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // PongMessage is the message expected for 'Pong' channel
@@ -404,7 +404,7 @@ type PongMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user on corresponding request
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -422,7 +422,7 @@ func NewPongMessage() PongMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -440,9 +440,9 @@ func newPongMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PongMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -466,9 +466,9 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -479,8 +479,8 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PongMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -488,7 +488,7 @@ func (msg PongMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PongMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -496,5 +496,5 @@ func (msg *PongMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PongMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }

--- a/examples/ping/nats/user/user.gen.go
+++ b/examples/ping/nats/user/user.gen.go
@@ -393,7 +393,7 @@ type PingMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -405,7 +405,7 @@ func NewPingMessage() PingMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -421,9 +421,9 @@ func newPingMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PingMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -444,9 +444,9 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -457,8 +457,8 @@ func (msg PingMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PingMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -466,7 +466,7 @@ func (msg PingMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PingMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -474,7 +474,7 @@ func (msg *PingMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PingMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // PongMessage is the message expected for 'Pong' channel
@@ -482,7 +482,7 @@ type PongMessage struct {
 	// Headers will be used to fill the message headers
 	Headers struct {
 		// Description: Correlation ID set by user on corresponding request
-		CorrelationID *string `json:"correlation_id"`
+		CorrelationId *string `json:"correlation_id"`
 	}
 
 	// Payload will be inserted in the message payload
@@ -500,7 +500,7 @@ func NewPongMessage() PongMessage {
 
 	// Set correlation ID
 	u := uuid.New().String()
-	msg.Headers.CorrelationID = &u
+	msg.Headers.CorrelationId = &u
 
 	return msg
 }
@@ -518,9 +518,9 @@ func newPongMessageFromBrokerMessage(bMsg extensions.BrokerMessage) (PongMessage
 	// Get each headers from broker message
 	for k, v := range bMsg.Headers {
 		switch {
-		case k == "correlationId": // Retrieving CorrelationID header
+		case k == "correlationId": // Retrieving CorrelationId header
 			h := string(v)
-			msg.Headers.CorrelationID = &h
+			msg.Headers.CorrelationId = &h
 		default:
 			// TODO: log unknown error
 		}
@@ -544,9 +544,9 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 	// Add each headers to broker message
 	headers := make(map[string][]byte, 1)
 
-	// Adding CorrelationID header
-	if msg.Headers.CorrelationID != nil {
-		headers["correlationId"] = []byte(*msg.Headers.CorrelationID)
+	// Adding CorrelationId header
+	if msg.Headers.CorrelationId != nil {
+		headers["correlationId"] = []byte(*msg.Headers.CorrelationId)
 	}
 
 	return extensions.BrokerMessage{
@@ -557,8 +557,8 @@ func (msg PongMessage) toBrokerMessage() (extensions.BrokerMessage, error) {
 
 // CorrelationID will give the correlation ID of the message, based on AsyncAPI spec
 func (msg PongMessage) CorrelationID() string {
-	if msg.Headers.CorrelationID != nil {
-		return *msg.Headers.CorrelationID
+	if msg.Headers.CorrelationId != nil {
+		return *msg.Headers.CorrelationId
 	}
 
 	return ""
@@ -566,7 +566,7 @@ func (msg PongMessage) CorrelationID() string {
 
 // SetCorrelationID will set the correlation ID of the message, based on AsyncAPI spec
 func (msg *PongMessage) SetCorrelationID(id string) {
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }
 
 // SetAsResponseFrom will correlate the message with the one passed in parameter.
@@ -574,5 +574,5 @@ func (msg *PongMessage) SetCorrelationID(id string) {
 // both specified in AsyncAPI spec.
 func (msg *PongMessage) SetAsResponseFrom(req MessageWithCorrelationID) {
 	id := req.CorrelationID()
-	msg.Headers.CorrelationID = &id
+	msg.Headers.CorrelationId = &id
 }

--- a/pkg/codegen/generators/templates/helpers.go
+++ b/pkg/codegen/generators/templates/helpers.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/lerenn/asyncapi-codegen/pkg/asyncapi"
-	"github.com/stoewer/go-strcase"
 )
 
 // NamifyWithoutParams will convert a sentence to a golang conventional type name.
@@ -22,32 +21,30 @@ func NamifyWithoutParams(sentence string) string {
 
 // Namify will convert a sentence to a golang conventional type name.
 func Namify(sentence string) string {
-	// Remove everything except alphanumerics and '_'
-	re := regexp.MustCompile("[^a-zA-Z0-9_]")
-	sentence = string(re.ReplaceAll([]byte(sentence), []byte("_")))
+	// Check if empty
+	if len(sentence) == 0 {
+		return sentence
+	}
+
+	// Upper letters that are preceded with an underscore
+	previous := '_'
+	for i, r := range sentence {
+		if previous == '_' {
+			sentence = sentence[:i] + strings.ToUpper(string(r)) + sentence[i+1:]
+		}
+		previous = r
+	}
+
+	// Remove everything except alphanumerics
+	re := regexp.MustCompile("[^a-zA-Z0-9]")
+	sentence = string(re.ReplaceAll([]byte(sentence), []byte("")))
 
 	// Remove leading numbers
 	re = regexp.MustCompile("^[0-9]+")
 	sentence = string(re.ReplaceAll([]byte(sentence), []byte("")))
 
-	// Snake case to Upper Camel case
-	sentence = strcase.UpperCamelCase(sentence)
-
-	// Correct acronyms
-	return correctAcronyms(sentence)
-}
-
-func correctAcronyms(sentence string) string {
-	acronyms := []string{"ID"}
-	for _, a := range acronyms {
-		wronglyFormatedAcronym := strcase.UpperCamelCase(a)
-		re := regexp.MustCompile(fmt.Sprintf("%s([A-Z]+|$)", wronglyFormatedAcronym))
-
-		positions := re.FindAllStringIndex(sentence, -1)
-		for _, p := range positions {
-			sentence = sentence[:p[0]] + a + sentence[p[0]+len(a):]
-		}
-	}
+	// Upper first letter
+	sentence = strings.ToUpper(sentence[:1]) + sentence[1:]
 
 	return sentence
 }

--- a/pkg/codegen/generators/templates/helpers_test.go
+++ b/pkg/codegen/generators/templates/helpers_test.go
@@ -21,6 +21,8 @@ type namifyCases struct {
 }
 
 var namifyBaseCases = []namifyCases{
+	// Nothing
+	{In: "", Out: ""},
 	// Remove leading digits
 	{In: "0name0", Out: "Name0"},
 	// Remove non alphanumerics
@@ -30,11 +32,14 @@ var namifyBaseCases = []namifyCases{
 	// Snake Case
 	{In: "eh_oh__ah", Out: "EhOhAh"},
 	// With acronym in middle
-	{In: "IdTata", Out: "IDTata"},
+	{In: "IDTata", Out: "IDTata"},
 	// With acronym in middle
-	{In: "TotoIdLala", Out: "TotoIDLala"},
+	{In: "TotoIDLala", Out: "TotoIDLala"},
+	{In: "Toto_IDLala", Out: "TotoIDLala"},
+	{In: "TotoSMALala", Out: "TotoSMALala"},
 	// With acronym at the end
-	{In: "TotoId", Out: "TotoID"},
+	{In: "TotoID", Out: "TotoID"},
+	{In: "Toto_ID", Out: "TotoID"},
 	// Without acronym, but still the same letters as the acronym
 	{In: "identity", Out: "Identity"},
 	{In: "Identity", Out: "Identity"},

--- a/test/issues/74/asyncapi.gen.go
+++ b/test/issues/74/asyncapi.gen.go
@@ -404,7 +404,7 @@ type TestMessage struct {
 	Payload struct {
 		Obj1 struct {
 			// Description: reference ID.
-			ReferenceID string `json:"reference_id"`
+			ReferenceId string `json:"reference_id"`
 		} `json:"obj1"`
 	}
 }
@@ -483,6 +483,6 @@ type HeaderSchema struct {
 type TestSchemaSchema struct {
 	Obj1 struct {
 		// Description: reference ID.
-		ReferenceID string `json:"reference_id"`
+		ReferenceId string `json:"reference_id"`
 	} `json:"obj1"`
 }


### PR DESCRIPTION
Listing all acronyms being a difficult task, it's better to let users specify their acronyms. So the new code won't put in lower case when there is several letters in upper case.