### PR TITLE
fix: capitalize letters following a non-alphanumeric character

### DIFF
--- a/pkg/codegen/generators/templates/helpers.go
+++ b/pkg/codegen/generators/templates/helpers.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/lerenn/asyncapi-codegen/pkg/asyncapi"
 )
@@ -29,7 +30,7 @@ func Namify(sentence string) string {
 	// Upper letters that are preceded with an underscore
 	previous := '_'
 	for i, r := range sentence {
-		if previous == '_' {
+		if !unicode.IsLetter(previous) && !unicode.IsDigit(previous) {
 			sentence = sentence[:i] + strings.ToUpper(string(r)) + sentence[i+1:]
 		}
 		previous = r

--- a/pkg/codegen/generators/templates/helpers_test.go
+++ b/pkg/codegen/generators/templates/helpers_test.go
@@ -31,6 +31,8 @@ var namifyBaseCases = []namifyCases{
 	{In: "name", Out: "Name"},
 	// Snake Case
 	{In: "eh_oh__ah", Out: "EhOhAh"},
+	// Weird delimiters
+	{In: "eh.oh__ah", Out: "EhOhAh"},
 	// With acronym in middle
 	{In: "IDTata", Out: "IDTata"},
 	// With acronym in middle


### PR DESCRIPTION
With the precedent fix, the letters following non-alphanumeric characters were not capitalized. It should fix it.