### PR TITLE
fix(brokers): change defaultQueue to ""

### DIFF
--- a/pkg/extensions/brokers/common.go
+++ b/pkg/extensions/brokers/common.go
@@ -2,7 +2,8 @@ package brokers
 
 const (
 	// DefaultQueueGroupID is the default queue name used by brokers.
-	DefaultQueueGroupID = "asyncapi"
+	// Note: empty in order to avoid using a queue group ID when not expected.
+	DefaultQueueGroupID = ""
 
 	// BrokerMessagesQueueSize is the size of the broker messages queue that
 	// will hold the messages processed from the broker to the universal format.

--- a/pkg/extensions/brokers/nats/nats.go
+++ b/pkg/extensions/brokers/nats/nats.go
@@ -88,13 +88,7 @@ func (c *Controller) Subscribe(ctx context.Context, channel string) (extensions.
 	)
 
 	// Subscribe on subject
-	var natsSub *nats.Subscription
-	var err error
-	if c.queueGroup == "" {
-		natsSub, err = c.connection.Subscribe(channel, messagesHandler(sub))
-	} else {
-		natsSub, err = c.connection.QueueSubscribe(channel, c.queueGroup, messagesHandler(sub))
-	}
+	natsSub, err := c.connection.QueueSubscribe(channel, c.queueGroup, messagesHandler(sub))
 	if err != nil {
 		return extensions.BrokerChannelSubscription{}, err
 	}


### PR DESCRIPTION
When using a user on an app, by default the queue id was "asyncapi". So when using the library without overriding it, then there was a chance that the user missed some response or the app missed some request. This should correct that.