### PR TITLE
fix(generators): v3 marshalling with additional properties

### DIFF
--- a/pkg/codegen/generators/v2/templates/marshaling/additional_properties.tmpl
+++ b/pkg/codegen/generators/v2/templates/marshaling/additional_properties.tmpl
@@ -1,6 +1,6 @@
 {{define "marshaling-additional-properties" -}}
 
-// MarshalJSON will override the marshal as this is not a normal 'time.Time' type
+// MarshalJSON marshals the schema into JSON with support for additional properties.
 func (t {{ .Name }}) MarshalJSON() ([]byte, error) {
     type alias {{ .Name }}
 
@@ -22,7 +22,7 @@ func (t {{ .Name }}) MarshalJSON() ([]byte, error) {
     return append(b, []byte("}")...) , nil
 }
 
-// UnmarshalJSON will override the unmarshal as this is not a normal 'time.Time' type
+// UnmarshalJSON unmarshals schema from JSON with support for additional properties.
 func (t *{{ .Name }}) UnmarshalJSON(data []byte) error {
     type alias {{ .Name }}
 
@@ -38,7 +38,7 @@ func (t *{{ .Name }}) UnmarshalJSON(data []byte) error {
     if err := json.Unmarshal(data, &a);  err != nil {
         return err
     }
-    *t = TestMapSchema(a)
+    *t = {{ .Name }}(a)
 
     // Get all fields that are additional and add them to the AdditionalProperties field.
     t.AdditionalProperties = make(map[string]{{template "schema-name" .AdditionalProperties}}, len(m))

--- a/pkg/codegen/generators/v3/templates/marshaling/additional_properties.tmpl
+++ b/pkg/codegen/generators/v3/templates/marshaling/additional_properties.tmpl
@@ -1,6 +1,6 @@
 {{define "marshaling-additional-properties" -}}
 
-// MarshalJSON will override the marshal as this is not a normal 'time.Time' type
+// MarshalJSON marshals the schema into JSON with support for additional properties.
 func (t {{ .Name }}) MarshalJSON() ([]byte, error) {
     type alias {{ .Name }}
 
@@ -22,7 +22,7 @@ func (t {{ .Name }}) MarshalJSON() ([]byte, error) {
     return append(b, []byte("}")...) , nil
 }
 
-// UnmarshalJSON will override the unmarshal as this is not a normal 'time.Time' type
+// UnmarshalJSON unmarshals schema from JSON with support for additional properties.
 func (t *{{ .Name }}) UnmarshalJSON(data []byte) error {
     type alias {{ .Name }}
 
@@ -38,7 +38,7 @@ func (t *{{ .Name }}) UnmarshalJSON(data []byte) error {
     if err := json.Unmarshal(data, &a);  err != nil {
         return err
     }
-    *t = TestMapSchema(a)
+    *t = {{ .Name }}(a)
 
     // Get all fields that are additional and add them to the AdditionalProperties field.
     t.AdditionalProperties = make(map[string]{{template "schema-name" .AdditionalProperties}}, len(m))

--- a/test/v2/issues/164/asyncapi.gen.go
+++ b/test/v2/issues/164/asyncapi.gen.go
@@ -474,7 +474,7 @@ type TestMapSchema struct {
 	AdditionalProperties map[string]string `json:"-"`
 }
 
-// MarshalJSON will override the marshal as this is not a normal 'time.Time' type
+// MarshalJSON marshals the schema into JSON with support for additional properties.
 func (t TestMapSchema) MarshalJSON() ([]byte, error) {
 	type alias TestMapSchema
 
@@ -496,7 +496,7 @@ func (t TestMapSchema) MarshalJSON() ([]byte, error) {
 	return append(b, []byte("}")...), nil
 }
 
-// UnmarshalJSON will override the unmarshal as this is not a normal 'time.Time' type
+// UnmarshalJSON unmarshals schema from JSON with support for additional properties.
 func (t *TestMapSchema) UnmarshalJSON(data []byte) error {
 	type alias TestMapSchema
 

--- a/test/v3/issues/164/asyncapi.gen.go
+++ b/test/v3/issues/164/asyncapi.gen.go
@@ -488,7 +488,7 @@ type TestMapSchema struct {
 	AdditionalProperties map[string]string `json:"-"`
 }
 
-// MarshalJSON will override the marshal as this is not a normal 'time.Time' type
+// MarshalJSON marshals the schema into JSON with support for additional properties.
 func (t TestMapSchema) MarshalJSON() ([]byte, error) {
 	type alias TestMapSchema
 
@@ -510,7 +510,7 @@ func (t TestMapSchema) MarshalJSON() ([]byte, error) {
 	return append(b, []byte("}")...), nil
 }
 
-// UnmarshalJSON will override the unmarshal as this is not a normal 'time.Time' type
+// UnmarshalJSON unmarshals schema from JSON with support for additional properties.
 func (t *TestMapSchema) UnmarshalJSON(data []byte) error {
 	type alias TestMapSchema
 


### PR DESCRIPTION
Fix generated code for marshalling additional properties. The test case for the behaviour relied on a harcoded struct name that should have used the templated name of the generated struct instead.