### PR TITLE
206: Nats Jetstream: consuming a message without subscription causes …

### DIFF
--- a/pkg/extensions/brokers/natsjetstream/natsjetstream.go
+++ b/pkg/extensions/brokers/natsjetstream/natsjetstream.go
@@ -311,6 +311,8 @@ func (c *Controller) ConsumeMessage(ctx context.Context) jetstream.MessageHandle
 				extensions.LogInfo{Key: "msg.data", Value: msg.Data()},
 			)
 			_ = msg.Ack()
+
+			return
 		}
 		c.channels[msg.Subject()] <- msg
 	}


### PR DESCRIPTION
…deadlock in the consumer

https://github.com/lerenn/asyncapi-codegen/issues/206