### PR TITLE
feat(brokers/nats-jetstream): allow passing an existing nats connection

### DIFF
--- a/pkg/extensions/brokers/natsjetstream/natsjetstream.go
+++ b/pkg/extensions/brokers/natsjetstream/natsjetstream.go
@@ -147,6 +147,14 @@ func WithConnectionOpts(opts ...nats.Option) ControllerOption {
 	}
 }
 
+// WithConnection uses the existing nats connection.
+func WithConnection(conn *nats.Conn) ControllerOption {
+	return func(controller *Controller) error {
+		controller.natsConn = conn
+		return nil
+	}
+}
+
 // registerConsumer set consumer configuration for creates or updates a consumer based on the given configuration
 // at the broker.
 func (c *Controller) registerConsumer() error {

--- a/pkg/extensions/brokers/natsjetstream/natsjetstream.go
+++ b/pkg/extensions/brokers/natsjetstream/natsjetstream.go
@@ -19,6 +19,7 @@ var _ extensions.BrokerController = (*Controller)(nil)
 type Controller struct {
 	url            string
 	natsConn       *nats.Conn
+	ownsNatsConn   bool
 	jetStream      jetstream.JetStream
 	logger         extensions.Logger
 	streamName     string
@@ -56,7 +57,7 @@ func NewController(url string, options ...ControllerOption) (*Controller, error)
 			return nil, fmt.Errorf("could not connect to nats: %w", err)
 		}
 
-		controller.natsConn = nc
+		controller.setNatsConnection(nc, true)
 	}
 
 	// Create a JetStream management interface
@@ -142,7 +143,7 @@ func WithConnectionOpts(opts ...nats.Option) ControllerOption {
 		if err != nil {
 			return fmt.Errorf("could not connect to nats: %w", err)
 		}
-		controller.natsConn = nc
+		controller.setNatsConnection(nc, true)
 		return nil
 	}
 }
@@ -150,9 +151,21 @@ func WithConnectionOpts(opts ...nats.Option) ControllerOption {
 // WithConnection uses the existing nats connection.
 func WithConnection(conn *nats.Conn) ControllerOption {
 	return func(controller *Controller) error {
-		controller.natsConn = conn
+		controller.setNatsConnection(conn, false)
 		return nil
 	}
+}
+
+// setNatsConnection replaces the current nats connection (in a non-thread-safe manner),
+// potentially closing the existing connection in the process.
+// It needs to be specified, if the given connection is owned or not. If it is owned, it
+// will be closed during the lifecycle of this controller. Otherwise, it will be kept alive.
+func (c *Controller) setNatsConnection(nc *nats.Conn, owning bool) {
+	if c.natsConn != nil && c.ownsNatsConn {
+		c.natsConn.Close()
+	}
+	c.natsConn = nc
+	c.ownsNatsConn = owning
 }
 
 // registerConsumer set consumer configuration for creates or updates a consumer based on the given configuration
@@ -275,7 +288,9 @@ func (c *Controller) HandleMessage(ctx context.Context, msg jetstream.Msg, sub e
 
 // Close closes everything related to the broker.
 func (c *Controller) Close() {
-	c.natsConn.Close()
+	if c.natsConn != nil && c.ownsNatsConn {
+		c.natsConn.Close()
+	}
 }
 
 // ConsumeIfNeeded starts consuming messages if needed.

--- a/pkg/extensions/brokers/natsjetstream/natsjetstream_test.go
+++ b/pkg/extensions/brokers/natsjetstream/natsjetstream_test.go
@@ -179,17 +179,16 @@ func TestSecureConnectionToNATSJetstream(t *testing.T) {
 		})
 }
 
-//nolint:funlen
 func TestExistingNatsConnection(t *testing.T) {
 	subj := "NatsJetstreamValidateConnection"
-	natsUrl := testutil.BrokerAddress(testutil.BrokerAddressParams{
+	natsURL := testutil.BrokerAddress(testutil.BrokerAddressParams{
 		Schema:         "nats",
 		DockerizedAddr: "nats-jetstream",
 		DockerizedPort: "4222",
 		LocalPort:      "4225",
 	})
 
-	nc, err := nats.Connect(natsUrl)
+	nc, err := nats.Connect(natsURL)
 	require.NoError(t, err, "nats connection should be established")
 	defer nc.Close()
 


### PR DESCRIPTION
This PR allows to pass an existing connection, so we don't have to open multiple connections from the same service.

> *Remark*: If a breaking API change is considered, I would even go so far as to remove the `URL` parameter completely and also remove the `WithConnectionOpts`. IMO the nats connection should always be handled on the outside to allow proper separation of concerns. 
>
> This would also solve edge cases like calling `WithConnectionOpts` multiple times, which would, at the moment, create multiple connections of which only the last one is closed.