### PR TITLE
fix: format-able spec

### DIFF
--- a/pkg/asyncapi/v2/schema.go
+++ b/pkg/asyncapi/v2/schema.go
@@ -96,7 +96,11 @@ func (s *Schema) generateMetadata(name string, isRequired bool) error {
 
 	// Set IsRequired
 	s.IsRequired = isRequired
-
+	if s.Type == "" {
+		if _, ok := s.Const.(string); ok {
+			s.Type = "string"
+		}
+	}
 	return nil
 }
 

--- a/pkg/codegen/generators/v2/templates/schema_definition.tmpl
+++ b/pkg/codegen/generators/v2/templates/schema_definition.tmpl
@@ -13,7 +13,7 @@ type {{ namify .Name }} struct {
     {{if $value.Description}}
     // Description: {{multiLineComment $value.Description}}
     {{else if and $value.ReferenceTo $value.ReferenceTo.Description}}
-    // Description: {{$value.ReferenceTo.Description}}
+    // Description: {{multiLineComment $value.ReferenceTo.Description}}
     {{end -}}
     {{namify $key}} {{if and (not (isRequired $ $key)) (ne $value.Type "array")}}*{{end}}{{template "schema-name" $value}} `json:"{{convertKey $key}}"{{generateValidateTags $value.Validations}}`
     {{end -}}

--- a/pkg/codegen/generators/v2/templates/schema_name.tmpl
+++ b/pkg/codegen/generators/v2/templates/schema_name.tmpl
@@ -71,8 +71,9 @@ struct {
 {{- else if .ReferenceTo -}}
 {{ namify .Follow.Name }}
 
-{{- /* ----------------------- Unsupported usecase ---------------------- */ -}}
+{{- /* ----------------------- Unsupported use case ---------------------- */ -}}
 {{- else -}}
+interface{}
 // WARNING: potential error in AsyncAPI generation
 // Infos on type: {{ describeStruct . }}
 {{- end -}}

--- a/pkg/codegen/generators/v3/templates/schema_definition.tmpl
+++ b/pkg/codegen/generators/v3/templates/schema_definition.tmpl
@@ -13,7 +13,7 @@ type {{ namify .Name }} struct {
     {{if $value.Description}}
     // Description: {{multiLineComment $value.Description}}
     {{else if and $value.ReferenceTo $value.ReferenceTo.Description}}
-    // Description: {{$value.ReferenceTo.Description}}
+    // Description: {{multiLineComment $value.ReferenceTo.Description}}
     {{end -}}
     {{namify $key}} {{if and (not (isRequired $ $key)) (ne $value.Type "array")}}*{{end}}{{template "schema-name" $value}} `json:"{{convertKey $key}}"{{generateValidateTags $value.Validations}}`
     {{end -}}

--- a/pkg/codegen/generators/v3/templates/schema_name.tmpl
+++ b/pkg/codegen/generators/v3/templates/schema_name.tmpl
@@ -73,6 +73,7 @@ struct {
 
 {{- /* ----------------------- Unsupported usecase ---------------------- */ -}}
 {{- else -}}
+interface{}
 // WARNING: potential error in AsyncAPI generation
 // Infos on type: {{ describeStruct . }}
 {{- end -}}

--- a/pkg/utils/template/helpers.go
+++ b/pkg/utils/template/helpers.go
@@ -64,7 +64,7 @@ func DefaultNamifier(sentence string) string {
 	if len(sentence) == 0 {
 		return sentence
 	}
-  
+
 	// Upper first letter
 	sentence = strings.ToUpper(sentence[:1]) + sentence[1:]
 

--- a/pkg/utils/template/helpers.go
+++ b/pkg/utils/template/helpers.go
@@ -61,7 +61,9 @@ func DefaultNamifier(sentence string) string {
 	// Remove leading numbers
 	re = regexp.MustCompile("^[0-9]+")
 	sentence = string(re.ReplaceAll([]byte(sentence), []byte("")))
-
+	if len(sentence) == 0 {
+		return sentence
+	}
 	// Upper first letter
 	sentence = strings.ToUpper(sentence[:1]) + sentence[1:]
 
@@ -116,10 +118,10 @@ func HasField(v any, name string) bool {
 	return rv.FieldByName(name).IsValid()
 }
 
-// DescribeStruct will describe a struct in a human readable way using `%+v`
+// DescribeStruct will describe a struct in a human-readable way using `%+v`
 // format from the standard library.
 func DescribeStruct(st any) string {
-	return fmt.Sprintf("%+v", st)
+	return MultiLineComment(fmt.Sprintf("%+v", st))
 }
 
 // MultiLineComment will prefix each line of a comment with "// " in order to


### PR DESCRIPTION
# Description

Couple of fixes for non-standard asyncapi spec, mainly https://demo.dxfeed.com/dxlink-ws/debug/assets/asyncapi-12629c76.yml.
- use `interface{}` for unsupported cases
- `MultiLineComment`  on DescribeStruct, since some of the struct "Description" could have new-line
- add `MultiLineComment` for struct field descriptions
- use "string" for consts