### PR TITLE
fix: add JSON omitempty and omitzero tags to asyncapiv3 types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - funlen
     - gci
     - gochecknoinits

--- a/build/ci/dagger/brokers.go
+++ b/build/ci/dagger/brokers.go
@@ -3,8 +3,6 @@ package main
 import (
 	"asyncapi-codegen/ci/dagger/internal/dagger"
 	"fmt"
-
-	testutil "github.com/lerenn/asyncapi-codegen/pkg/utils/test"
 )
 
 const (
@@ -74,7 +72,7 @@ func kafkaSingleNodeEnv(c *dagger.Container, advertisedHost, protocolMap string)
 // a combined keystore (certificate chain + private key in a single file) and a
 // CA truststore so the broker trusts its own certificate over SSL/SASL_SSL.
 func kafkaTLSDirectory(host string) *dagger.Directory {
-	key, cert, cacert, err := testutil.GenerateSelfSignedCertificateWithCA(host)
+	key, cert, cacert, err := GenerateSelfSignedCertificateWithCA(host)
 	if err != nil {
 		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
 	}
@@ -168,7 +166,7 @@ func brokerNATS() *dagger.Container {
 
 // brokerNATSSecure returns a container for the NATS broker secured with TLS.
 func brokerNATSSecure() *dagger.Container {
-	key, cert, err := testutil.GenerateSelfSignedCertificate("nats-tls")
+	key, cert, err := GenerateSelfSignedCertificate("nats-tls")
 	if err != nil {
 		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
 	}
@@ -189,7 +187,7 @@ func brokerNATSSecure() *dagger.Container {
 // brokerNATSSecureBasicAuth returns a container for the NATS broker secured with TLS
 // and basic auth user: user password: password.
 func brokerNATSSecureBasicAuth() *dagger.Container {
-	key, cert, err := testutil.GenerateSelfSignedCertificate("nats-tls-basic-auth")
+	key, cert, err := GenerateSelfSignedCertificate("nats-tls-basic-auth")
 	if err != nil {
 		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
 	}
@@ -227,7 +225,7 @@ func brokerNATSJetstream() *dagger.Container {
 
 // brokerNATSJetstreamSecure returns a container for the NATS broker secured with TLS.
 func brokerNATSJetstreamSecure() *dagger.Container {
-	key, cert, err := testutil.GenerateSelfSignedCertificate("nats-jetstream-tls-basic-auth")
+	key, cert, err := GenerateSelfSignedCertificate("nats-jetstream-tls-basic-auth")
 	if err != nil {
 		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
 	}
@@ -248,7 +246,7 @@ func brokerNATSJetstreamSecure() *dagger.Container {
 // brokerNATSJetstreamSecureBasicAuth returns a container for the NATS broker secured with TLS
 // and basic auth user: user password: password.
 func brokerNATSJetstreamSecureBasicAuth() *dagger.Container {
-	key, cert, err := testutil.GenerateSelfSignedCertificate("nats-jetstream-tls")
+	key, cert, err := GenerateSelfSignedCertificate("nats-jetstream-tls")
 	if err != nil {
 		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
 	}

--- a/build/ci/dagger/certs.go
+++ b/build/ci/dagger/certs.go
@@ -1,0 +1,121 @@
+package main
+
+// NOTE: these self-signed certificate helpers are intentionally kept local to
+// the CI module so that it does not import the asyncapi-codegen library itself.
+// Importing the library would couple this tooling module to the library's
+// go.mod version, which would force the Dagger engine to load a newer Go
+// toolchain than it bundles. They mirror pkg/utils/test/certs.go.
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+)
+
+// GenerateSelfSignedCertificate generates a self-signed certificate.
+func GenerateSelfSignedCertificate(name string) ([]byte, []byte, error) {
+	// Generate private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := certificateTemplateForHost(name)
+
+	// Generate self-signed certificate
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encode private key to PEM format
+	keyBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+
+	// Encode certificate to PEM format
+	certBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	return keyBytes, certBytes, nil
+}
+
+// GenerateSelfSignedCertificateWithCA generates a self-signed certificate with a CA certificate.
+func GenerateSelfSignedCertificateWithCA(name string) ([]byte, []byte, []byte, error) {
+	// Generate private key for CA
+	caPrivateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Create a self-signed CA certificate
+	caCertTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2), // Use a different serial number for the CA certificate
+		Subject: pkix.Name{
+			Organization: []string{"asyncapi-codegen"},
+			CommonName:   "CA asyncapi-codegen",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0), // Valid for 10 years
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	// Generate self-signed CA certificate
+	caDERBytes, err := x509.CreateCertificate(rand.Reader, &caCertTemplate, &caCertTemplate,
+		&caPrivateKey.PublicKey, caPrivateKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Generate private key for server
+	privateKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Create server certificate signed by CA
+	certTemplate := certificateTemplateForHost(name)
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &caCertTemplate,
+		&privateKey.PublicKey, caPrivateKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Convert private key to PKCS #8
+	privatKeyPKC8Bytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Encode server private key to PEM format
+	keyBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privatKeyPKC8Bytes})
+
+	// Encode server certificate to PEM format
+	certBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	// Encode CA certificate to PEM format
+	caCertBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDERBytes})
+
+	return keyBytes, certBytes, caCertBytes, nil
+}
+
+func certificateTemplateForHost(name string) x509.Certificate {
+	return x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:       []string{"asyncapi-codegen"},
+			OrganizationalUnit: []string{"localtest"},
+			CommonName:         name,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(0, 0, 1), // Valid for 1 day
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{name, "localhost", "127.0.0.1"},
+	}
+}

--- a/build/ci/dagger/go.mod
+++ b/build/ci/dagger/go.mod
@@ -5,7 +5,6 @@ go 1.21.7
 require (
 	github.com/99designs/gqlgen v0.17.49
 	github.com/Khan/genqlient v0.7.0
-	github.com/lerenn/asyncapi-codegen v0.34.0
 	github.com/vektah/gqlparser/v2 v2.5.16
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	golang.org/x/sync v0.7.0
@@ -39,5 +38,3 @@ require (
 	google.golang.org/grpc v1.64.0
 	google.golang.org/protobuf v1.34.1 // indirect
 )
-
-replace github.com/lerenn/asyncapi-codegen => ../../../

--- a/build/ci/dagger/module.go
+++ b/build/ci/dagger/module.go
@@ -21,9 +21,9 @@ import (
 
 const (
 	// linterImage is the image used for linter.
-	linterImage = "golangci/golangci-lint:v1.62.0"
+	linterImage = "golangci/golangci-lint:v1.64.8"
 	// golangImage is the image used as base for golang operations.
-	golangImage = "golang:1.21.4-alpine"
+	golangImage = "golang:1.24-alpine"
 )
 
 // AsyncapiCodegenCi is the Dagger CI module for AsyncAPI Codegen.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/lerenn/asyncapi-codegen
 
-go 1.21
+go 1.24
 
-toolchain go1.21.4
+toolchain go1.24.0
 
 require (
 	cloud.google.com/go v0.114.0

--- a/pkg/asyncapi/schema.go
+++ b/pkg/asyncapi/schema.go
@@ -3,26 +3,26 @@ package asyncapi
 // Validations is a representation of the JSON-Object validation fields supported by asyncapi
 // These fields are in common for v2 and v3.
 type Validations[T any] struct {
-	Required         []string `json:"required"`
-	MultipleOf       []string `json:"multipleOf"`
-	Maximum          float64  `json:"maximum"`
-	ExclusiveMaximum float64  `json:"exclusiveMaximum"`
-	Minimum          float64  `json:"minimum"`
-	ExclusiveMinimum float64  `json:"exclusiveMinimum"`
-	MaxLength        uint     `json:"maxLength"`
-	MinLength        uint     `json:"minLength"`
-	Pattern          string   `json:"pattern"`
-	MaxItems         uint     `json:"maxItems"`
-	MinItems         uint     `json:"minItems"`
-	UniqueItems      bool     `json:"uniqueItems"`
-	MaxProperties    uint     `json:"maxProperties"`
-	MinProperties    uint     `json:"minProperties"`
-	Enum             []any    `json:"enum"`
-	Const            any      `json:"const"`
+	Required         []string `json:"required,omitempty"`
+	MultipleOf       []string `json:"multipleOf,omitempty"`
+	Maximum          float64  `json:"maximum,omitempty"`
+	ExclusiveMaximum float64  `json:"exclusiveMaximum,omitempty"`
+	Minimum          float64  `json:"minimum,omitempty"`
+	ExclusiveMinimum float64  `json:"exclusiveMinimum,omitempty"`
+	MaxLength        uint     `json:"maxLength,omitempty"`
+	MinLength        uint     `json:"minLength,omitempty"`
+	Pattern          string   `json:"pattern,omitempty"`
+	MaxItems         uint     `json:"maxItems,omitempty"`
+	MinItems         uint     `json:"minItems,omitempty"`
+	UniqueItems      bool     `json:"uniqueItems,omitempty"`
+	MaxProperties    uint     `json:"maxProperties,omitempty"`
+	MinProperties    uint     `json:"minProperties,omitempty"`
+	Enum             []any    `json:"enum,omitempty"`
+	Const            any      `json:"const,omitempty"`
 
-	AllOf []*T `json:"allOf"`
-	AnyOf []*T `json:"anyOf"`
-	OneOf []*T `json:"oneOf"`
+	AllOf []*T `json:"allOf,omitempty"`
+	AnyOf []*T `json:"anyOf,omitempty"`
+	OneOf []*T `json:"oneOf,omitempty"`
 
 	// --- Non JSON Schema/AsyncAPI fields -------------------------------------
 	IsRequired      bool  `json:"-"`

--- a/pkg/asyncapi/v3/channel.go
+++ b/pkg/asyncapi/v3/channel.go
@@ -22,17 +22,19 @@ var (
 type Channel struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Address      string                 `json:"address"`
-	Messages     map[string]*Message    `json:"messages"`
-	Title        string                 `json:"title"`
-	Summary      string                 `json:"summary"`
-	Description  string                 `json:"description"`
-	Servers      []*Server              `json:"servers"` // Reference only
-	Parameters   map[string]*Parameter  `json:"parameters"`
-	Tags         []*Tag                 `json:"tags"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs"`
-	Bindings     *ChannelBindings       `json:"bindings"`
-	Reference    string                 `json:"$ref"`
+	// NOTE: the JSON null literal is a valid value for address, which cannot be parsed as a Go string
+	// Solutions are to change to a *string (a breaking change) or use a wrapper type like sql.NullString
+	Address      string                 `json:"address,omitempty"`
+	Messages     map[string]*Message    `json:"messages,omitempty"`
+	Title        string                 `json:"title,omitempty"`
+	Summary      string                 `json:"summary,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Servers      []*Server              `json:"servers,omitempty"` // Reference only
+	Parameters   map[string]*Parameter  `json:"parameters,omitempty"`
+	Tags         []*Tag                 `json:"tags,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Bindings     *ChannelBindings       `json:"bindings,omitempty"`
+	Reference    string                 `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/channel_bindings.go
+++ b/pkg/asyncapi/v3/channel_bindings.go
@@ -6,26 +6,26 @@ package asyncapiv3
 type ChannelBindings struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	HTTP         HTTPBinding         `json:"http"`
-	WS           WsBinding           `json:"ws"`
-	Kafka        KafkaBinding        `json:"kafka"`
-	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq"`
-	AMQP         AMQPBinding         `json:"amqp"`
-	AMQP1        AMQP1Binding        `json:"amqp1"`
-	MQTT         MQTTBinding         `json:"mqtt"`
-	MQTT5        MQTT5Binding        `json:"mqtt5"`
-	NATS         NATSBinding         `json:"nats"`
-	JMS          JMSBinding          `json:"jms"`
-	SNS          SNSBinding          `json:"sns"`
-	Solace       SolaceBinding       `json:"solace"`
-	SQS          SQSBinding          `json:"sqs"`
-	Stomp        StompBinding        `json:"stomp"`
-	Redis        RedisBinding        `json:"redis"`
-	Mercure      MercureBinding      `json:"mercure"`
-	IBMMQ        IBMMQBinding        `json:"ibmmq"`
-	GooglePubSub GooglePubSubBinding `json:"googlepubsub"`
-	Pulsar       PulsarBinding       `json:"pulsar"`
-	Reference    string              `json:"$ref"`
+	HTTP         HTTPBinding         `json:"http,omitzero"`
+	WS           WsBinding           `json:"ws,omitzero"`
+	Kafka        KafkaBinding        `json:"kafka,omitzero"`
+	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq,omitzero"`
+	AMQP         AMQPBinding         `json:"amqp,omitzero"`
+	AMQP1        AMQP1Binding        `json:"amqp1,omitzero"`
+	MQTT         MQTTBinding         `json:"mqtt,omitzero"`
+	MQTT5        MQTT5Binding        `json:"mqtt5,omitzero"`
+	NATS         NATSBinding         `json:"nats,omitzero"`
+	JMS          JMSBinding          `json:"jms,omitzero"`
+	SNS          SNSBinding          `json:"sns,omitzero"`
+	Solace       SolaceBinding       `json:"solace,omitzero"`
+	SQS          SQSBinding          `json:"sqs,omitzero"`
+	Stomp        StompBinding        `json:"stomp,omitzero"`
+	Redis        RedisBinding        `json:"redis,omitzero"`
+	Mercure      MercureBinding      `json:"mercure,omitzero"`
+	IBMMQ        IBMMQBinding        `json:"ibmmq,omitzero"`
+	GooglePubSub GooglePubSubBinding `json:"googlepubsub,omitzero"`
+	Pulsar       PulsarBinding       `json:"pulsar,omitzero"`
+	Reference    string              `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/components.go
+++ b/pkg/asyncapi/v3/components.go
@@ -6,25 +6,25 @@ package asyncapiv3
 type Components struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Schemas           map[string]*Schema                `json:"schemas"`
-	Servers           map[string]*Server                `json:"servers"`
-	Channels          map[string]*Channel               `json:"channels"`
-	Operations        map[string]*Operation             `json:"operations"`
-	Messages          map[string]*Message               `json:"messages"`
-	SecuritySchemes   map[string]*SecurityScheme        `json:"securitySchemes"`
-	ServerVariables   map[string]*ServerVariable        `json:"serverVariables"`
-	Parameters        map[string]*Parameter             `json:"parameters"`
-	CorrelationIDs    map[string]*CorrelationID         `json:"correlationIds"`
-	Replies           map[string]*OperationReply        `json:"replies"`
-	ReplyAddresses    map[string]*OperationReplyAddress `json:"replyAddresses"`
-	ExternalDocs      map[string]*ExternalDocumentation `json:"externalDocs"`
-	Tags              map[string]*Tag                   `json:"tags"`
-	OperationTraits   map[string]*OperationTrait        `json:"operationTraits"`
-	MessageTraits     map[string]*MessageTrait          `json:"messageTraits"`
-	ServerBindings    map[string]*ServerBindings        `json:"serverBindings"`
-	ChannelBindings   map[string]*ChannelBindings       `json:"channelBindings"`
-	OperationBindings map[string]*OperationBindings     `json:"operationBindings"`
-	MessageBindings   map[string]*MessageBindings       `json:"messageBindings"`
+	Schemas           map[string]*Schema                `json:"schemas,omitempty"`
+	Servers           map[string]*Server                `json:"servers,omitempty"`
+	Channels          map[string]*Channel               `json:"channels,omitempty"`
+	Operations        map[string]*Operation             `json:"operations,omitempty"`
+	Messages          map[string]*Message               `json:"messages,omitempty"`
+	SecuritySchemes   map[string]*SecurityScheme        `json:"securitySchemes,omitempty"`
+	ServerVariables   map[string]*ServerVariable        `json:"serverVariables,omitempty"`
+	Parameters        map[string]*Parameter             `json:"parameters,omitempty"`
+	CorrelationIDs    map[string]*CorrelationID         `json:"correlationIds,omitempty"`
+	Replies           map[string]*OperationReply        `json:"replies,omitempty"`
+	ReplyAddresses    map[string]*OperationReplyAddress `json:"replyAddresses,omitempty"`
+	ExternalDocs      map[string]*ExternalDocumentation `json:"externalDocs,omitempty"`
+	Tags              map[string]*Tag                   `json:"tags,omitempty"`
+	OperationTraits   map[string]*OperationTrait        `json:"operationTraits,omitempty"`
+	MessageTraits     map[string]*MessageTrait          `json:"messageTraits,omitempty"`
+	ServerBindings    map[string]*ServerBindings        `json:"serverBindings,omitempty"`
+	ChannelBindings   map[string]*ChannelBindings       `json:"channelBindings,omitempty"`
+	OperationBindings map[string]*OperationBindings     `json:"operationBindings,omitempty"`
+	MessageBindings   map[string]*MessageBindings       `json:"messageBindings,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 }

--- a/pkg/asyncapi/v3/contact.go
+++ b/pkg/asyncapi/v3/contact.go
@@ -6,9 +6,9 @@ package asyncapiv3
 type Contact struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Name  string `json:"name"`
-	URL   string `json:"url"`
-	Email string `json:"email"`
+	Name  string `json:"name,omitempty"`
+	URL   string `json:"url,omitempty"`
+	Email string `json:"email,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 }

--- a/pkg/asyncapi/v3/correlation_id.go
+++ b/pkg/asyncapi/v3/correlation_id.go
@@ -6,9 +6,9 @@ package asyncapiv3
 type CorrelationID struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Description string `json:"description"`
-	Location    string `json:"location"`
-	Reference   string `json:"$ref"`
+	Description string `json:"description,omitempty"`
+	Location    string `json:"location,omitempty"`
+	Reference   string `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/extensions.go
+++ b/pkg/asyncapi/v3/extensions.go
@@ -9,14 +9,14 @@ import (
 // that are out of the AsyncAPI spec.
 type Extensions struct {
 	// Setting custom Go type when generating schemas
-	ExtGoType string `json:"x-go-type"`
+	ExtGoType string `json:"x-go-type,omitempty"`
 
 	// Setting custom import statements for ExtGoType
-	ExtGoTypeImport *GoTypeImportExtension `json:"x-go-type-import"`
+	ExtGoTypeImport *GoTypeImportExtension `json:"x-go-type-import,omitempty"`
 
 	// Controls whether to include omitempty in JSON tags
 	// If false, omitempty will be removed from JSON tags even if the field can be null
-	ExtOmitEmpty *bool `json:"x-omitempty"`
+	ExtOmitEmpty *bool `json:"x-omitempty,omitempty"`
 }
 
 // GoTypeImportExtension specifies the required import statement

--- a/pkg/asyncapi/v3/external_documentation.go
+++ b/pkg/asyncapi/v3/external_documentation.go
@@ -11,9 +11,9 @@ const (
 type ExternalDocumentation struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	URL         string `json:"url"`
-	Reference   string `json:"$ref"`
+	Reference   string `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/info.go
+++ b/pkg/asyncapi/v3/info.go
@@ -8,12 +8,12 @@ type Info struct {
 
 	Title          string                 `json:"title"`
 	Version        string                 `json:"version"`
-	Description    string                 `json:"description"`
-	TermsOfService string                 `json:"termsOfService"`
-	Contact        *Contact               `json:"contact"`
-	License        *License               `json:"license"`
-	Tags           []*Tag                 `json:"tags"`
-	ExternalDocs   *ExternalDocumentation `json:"externalDocs"`
+	Description    string                 `json:"description,omitempty"`
+	TermsOfService string                 `json:"termsOfService,omitempty"`
+	Contact        *Contact               `json:"contact,omitempty"`
+	License        *License               `json:"license,omitempty"`
+	Tags           []*Tag                 `json:"tags,omitempty"`
+	ExternalDocs   *ExternalDocumentation `json:"externalDocs,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 }

--- a/pkg/asyncapi/v3/license.go
+++ b/pkg/asyncapi/v3/license.go
@@ -7,7 +7,7 @@ type License struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
 	Name string `json:"name"`
-	URL  string `json:"url"`
+	URL  string `json:"url,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 }

--- a/pkg/asyncapi/v3/message.go
+++ b/pkg/asyncapi/v3/message.go
@@ -37,21 +37,21 @@ const (
 type Message struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Headers       *Schema                `json:"headers"`
-	Payload       *Schema                `json:"payload"`
-	OneOf         []*Message             `json:"oneOf"`
-	CorrelationID *CorrelationID         `json:"correlationID"`
-	ContentType   string                 `json:"contentType"`
-	Name          string                 `json:"name"`
-	Title         string                 `json:"title"`
-	Summary       string                 `json:"summary"`
-	Description   string                 `json:"description"`
-	Tags          []*Tag                 `json:"tags"`
-	ExternalDocs  *ExternalDocumentation `json:"externalDocs"`
-	Bindings      *MessageBindings       `json:"bindings"`
-	Examples      []*MessageExample      `json:"examples"`
-	Traits        []*MessageTrait        `json:"traits"`
-	Reference     string                 `json:"$ref"`
+	Headers       *Schema                `json:"headers,omitempty"`
+	Payload       *Schema                `json:"payload,omitempty"`
+	OneOf         []*Message             `json:"oneOf,omitempty"`
+	CorrelationID *CorrelationID         `json:"correlationID,omitempty"`
+	ContentType   string                 `json:"contentType,omitempty"`
+	Name          string                 `json:"name,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Tags          []*Tag                 `json:"tags,omitempty"`
+	ExternalDocs  *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Bindings      *MessageBindings       `json:"bindings,omitempty"`
+	Examples      []*MessageExample      `json:"examples,omitempty"`
+	Traits        []*MessageTrait        `json:"traits,omitempty"`
+	Reference     string                 `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/message_bindings.go
+++ b/pkg/asyncapi/v3/message_bindings.go
@@ -6,26 +6,26 @@ package asyncapiv3
 type MessageBindings struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	HTTP         HTTPBinding         `json:"http"`
-	WS           WsBinding           `json:"ws"`
-	Kafka        KafkaBinding        `json:"kafka"`
-	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq"`
-	AMQP         AMQPBinding         `json:"amqp"`
-	AMQP1        AMQP1Binding        `json:"amqp1"`
-	MQTT         MQTTBinding         `json:"mqtt"`
-	MQTT5        MQTT5Binding        `json:"mqtt5"`
-	NATS         NATSBinding         `json:"nats"`
-	JMS          JMSBinding          `json:"jms"`
-	SNS          SNSBinding          `json:"sns"`
-	Solace       SolaceBinding       `json:"solace"`
-	SQS          SQSBinding          `json:"sqs"`
-	Stomp        StompBinding        `json:"stomp"`
-	Redis        RedisBinding        `json:"redis"`
-	Mercure      MercureBinding      `json:"mercure"`
-	IBMMQ        IBMMQBinding        `json:"ibmmq"`
-	GooglePubSub GooglePubSubBinding `json:"googlepubsub"`
-	Pulsar       PulsarBinding       `json:"pulsar"`
-	Reference    string              `json:"$ref"`
+	HTTP         HTTPBinding         `json:"http,omitzero"`
+	WS           WsBinding           `json:"ws,omitzero"`
+	Kafka        KafkaBinding        `json:"kafka,omitzero"`
+	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq,omitzero"`
+	AMQP         AMQPBinding         `json:"amqp,omitzero"`
+	AMQP1        AMQP1Binding        `json:"amqp1,omitzero"`
+	MQTT         MQTTBinding         `json:"mqtt,omitzero"`
+	MQTT5        MQTT5Binding        `json:"mqtt5,omitzero"`
+	NATS         NATSBinding         `json:"nats,omitzero"`
+	JMS          JMSBinding          `json:"jms,omitzero"`
+	SNS          SNSBinding          `json:"sns,omitzero"`
+	Solace       SolaceBinding       `json:"solace,omitzero"`
+	SQS          SQSBinding          `json:"sqs,omitzero"`
+	Stomp        StompBinding        `json:"stomp,omitzero"`
+	Redis        RedisBinding        `json:"redis,omitzero"`
+	Mercure      MercureBinding      `json:"mercure,omitzero"`
+	IBMMQ        IBMMQBinding        `json:"ibmmq,omitzero"`
+	GooglePubSub GooglePubSubBinding `json:"googlepubsub,omitzero"`
+	Pulsar       PulsarBinding       `json:"pulsar,omitzero"`
+	Reference    string              `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/message_example.go
+++ b/pkg/asyncapi/v3/message_example.go
@@ -6,11 +6,11 @@ package asyncapiv3
 type MessageExample struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Headers   map[string]any `json:"headers"`
-	Payload   map[string]any `json:"payload"`
-	Name      string         `json:"name"`
-	Summary   string         `json:"summary"`
-	Reference string         `json:"$ref"`
+	Headers   map[string]any `json:"headers,omitempty"`
+	Payload   map[string]any `json:"payload,omitempty"`
+	Name      string         `json:"name,omitempty"`
+	Summary   string         `json:"summary,omitempty"`
+	Reference string         `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/message_trait.go
+++ b/pkg/asyncapi/v3/message_trait.go
@@ -6,19 +6,20 @@ package asyncapiv3
 type MessageTrait struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Headers       *Schema                `json:"headers"`
-	Payload       *Schema                `json:"payload"`
-	CorrelationID *CorrelationID         `json:"correlationID"`
-	ContentType   string                 `json:"contentType"`
-	Name          string                 `json:"name"`
-	Title         string                 `json:"title"`
-	Summary       string                 `json:"summary"`
-	Description   string                 `json:"description"`
-	Tags          []*Tag                 `json:"tags"`
-	ExternalDocs  *ExternalDocumentation `json:"externalDocs"`
-	Bindings      *MessageBindings       `json:"bindings"`
-	Examples      []*MessageExample      `json:"examples"`
-	Reference     string                 `json:"$ref"`
+	Headers *Schema `json:"headers,omitempty"`
+	// NOTE: "payload" is explicitly disallowed: https://github.com/asyncapi/spec/blob/c5888f52b70f8eb99f782df9d23a88e1a4dce112/spec/asyncapi.md?plain=1#L1414
+	Payload       *Schema                `json:"payload,omitempty"`
+	CorrelationID *CorrelationID         `json:"correlationID,omitempty"`
+	ContentType   string                 `json:"contentType,omitempty"`
+	Name          string                 `json:"name,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Tags          []*Tag                 `json:"tags,omitempty"`
+	ExternalDocs  *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Bindings      *MessageBindings       `json:"bindings,omitempty"`
+	Examples      []*MessageExample      `json:"examples,omitempty"`
+	Reference     string                 `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/message_trait.go
+++ b/pkg/asyncapi/v3/message_trait.go
@@ -7,7 +7,8 @@ type MessageTrait struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
 	Headers *Schema `json:"headers,omitempty"`
-	// NOTE: "payload" is explicitly disallowed: https://github.com/asyncapi/spec/blob/c5888f52b70f8eb99f782df9d23a88e1a4dce112/spec/asyncapi.md?plain=1#L1414
+	// NOTE: "payload" is explicitly disallowed by the AsyncAPI spec:
+	// https://github.com/asyncapi/spec/blob/c5888f52b70f8eb99f782df9d23a88e1a4dce112/spec/asyncapi.md?plain=1#L1414
 	Payload       *Schema                `json:"payload,omitempty"`
 	CorrelationID *CorrelationID         `json:"correlationID,omitempty"`
 	ContentType   string                 `json:"contentType,omitempty"`

--- a/pkg/asyncapi/v3/operation.go
+++ b/pkg/asyncapi/v3/operation.go
@@ -23,22 +23,29 @@ func (oa OperationAction) IsReceive() bool {
 // Operation is a representation of the corresponding asyncapi object filled
 // from an asyncapi specification that will be used to generate code.
 // Source: https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject
+//
+// NOTE: From AsyncAPI specification on the "messages" field:
+//
+//	Excluding this property from the Operation implies that all messages from the channel will be included. Explicitly set the messages property to [] if this operation should contain no messages.
+//
+// Because of this caveat, it must be possible to both serialize the messages slice as an empty JSON array or exclude the key entirely.
+// The omitzero tag is required to enable this.
 type Operation struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
 	Action       OperationAction        `json:"action"`
 	Channel      *Channel               `json:"channel"` // Reference only
-	Title        string                 `json:"title"`
-	Summary      string                 `json:"summary"`
-	Description  string                 `json:"string"`
-	Security     []*SecurityScheme      `json:"security"`
-	Tags         []*Tag                 `json:"tags"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs"`
-	Bindings     *OperationBindings     `json:"bindings"`
-	Traits       []*OperationTrait      `json:"traits"`
-	Messages     []*Message             `json:"messages"` // References only
-	Reply        *OperationReply        `json:"reply"`
-	Reference    string                 `json:"$ref"`
+	Title        string                 `json:"title,omitempty"`
+	Summary      string                 `json:"summary,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Security     []*SecurityScheme      `json:"security,omitempty"`
+	Tags         []*Tag                 `json:"tags,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Bindings     *OperationBindings     `json:"bindings,omitempty"`
+	Traits       []*OperationTrait      `json:"traits,omitempty"`
+	Messages     []*Message             `json:"messages,omitzero"` // References only
+	Reply        *OperationReply        `json:"reply,omitempty"`
+	Reference    string                 `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/operation.go
+++ b/pkg/asyncapi/v3/operation.go
@@ -24,12 +24,15 @@ func (oa OperationAction) IsReceive() bool {
 // from an asyncapi specification that will be used to generate code.
 // Source: https://www.asyncapi.com/docs/reference/specification/v3.0.0#operationObject
 //
-// NOTE: From AsyncAPI specification on the "messages" field:
+// NOTE: From the AsyncAPI specification on the "messages" field:
 //
-//	Excluding this property from the Operation implies that all messages from the channel will be included. Explicitly set the messages property to [] if this operation should contain no messages.
+//	Excluding this property from the Operation implies that all messages
+//	from the channel will be included. Explicitly set the messages property
+//	to [] if this operation should contain no messages.
 //
-// Because of this caveat, it must be possible to both serialize the messages slice as an empty JSON array or exclude the key entirely.
-// The omitzero tag is required to enable this.
+// Because of this caveat, it must be possible to both serialize the messages
+// slice as an empty JSON array or exclude the key entirely. The omitzero tag
+// is required to enable this.
 type Operation struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 

--- a/pkg/asyncapi/v3/operation_bindings.go
+++ b/pkg/asyncapi/v3/operation_bindings.go
@@ -6,26 +6,26 @@ package asyncapiv3
 type OperationBindings struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	HTTP         HTTPBinding         `json:"http"`
-	WS           WsBinding           `json:"ws"`
-	Kafka        KafkaBinding        `json:"kafka"`
-	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq"`
-	AMQP         AMQPBinding         `json:"amqp"`
-	AMQP1        AMQP1Binding        `json:"amqp1"`
-	MQTT         MQTTBinding         `json:"mqtt"`
-	MQTT5        MQTT5Binding        `json:"mqtt5"`
-	NATS         NATSBinding         `json:"nats"`
-	JMS          JMSBinding          `json:"jms"`
-	SNS          SNSBinding          `json:"sns"`
-	Solace       SolaceBinding       `json:"solace"`
-	SQS          SQSBinding          `json:"sqs"`
-	Stomp        StompBinding        `json:"stomp"`
-	Redis        RedisBinding        `json:"redis"`
-	Mercure      MercureBinding      `json:"mercure"`
-	IBMMQ        IBMMQBinding        `json:"ibmmq"`
-	GooglePubSub GooglePubSubBinding `json:"googlepubsub"`
-	Pulsar       PulsarBinding       `json:"pulsar"`
-	Reference    string              `json:"$ref"`
+	HTTP         HTTPBinding         `json:"http,omitzero"`
+	WS           WsBinding           `json:"ws,omitzero"`
+	Kafka        KafkaBinding        `json:"kafka,omitzero"`
+	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq,omitzero"`
+	AMQP         AMQPBinding         `json:"amqp,omitzero"`
+	AMQP1        AMQP1Binding        `json:"amqp1,omitzero"`
+	MQTT         MQTTBinding         `json:"mqtt,omitzero"`
+	MQTT5        MQTT5Binding        `json:"mqtt5,omitzero"`
+	NATS         NATSBinding         `json:"nats,omitzero"`
+	JMS          JMSBinding          `json:"jms,omitzero"`
+	SNS          SNSBinding          `json:"sns,omitzero"`
+	Solace       SolaceBinding       `json:"solace,omitzero"`
+	SQS          SQSBinding          `json:"sqs,omitzero"`
+	Stomp        StompBinding        `json:"stomp,omitzero"`
+	Redis        RedisBinding        `json:"redis,omitzero"`
+	Mercure      MercureBinding      `json:"mercure,omitzero"`
+	IBMMQ        IBMMQBinding        `json:"ibmmq,omitzero"`
+	GooglePubSub GooglePubSubBinding `json:"googlepubsub,omitzero"`
+	Pulsar       PulsarBinding       `json:"pulsar,omitzero"`
+	Reference    string              `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/operation_reply.go
+++ b/pkg/asyncapi/v3/operation_reply.go
@@ -6,10 +6,10 @@ package asyncapiv3
 type OperationReply struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Address   *OperationReplyAddress `json:"address"`
-	Channel   *Channel               `json:"channel"`  // Reference only
-	Messages  []*Message             `json:"messages"` // References only
-	Reference string                 `json:"$ref"`
+	Address   *OperationReplyAddress `json:"address,omitempty"`
+	Channel   *Channel               `json:"channel,omitempty"`  // Reference only
+	Messages  []*Message             `json:"messages,omitempty"` // References only
+	Reference string                 `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/operation_reply_address.go
+++ b/pkg/asyncapi/v3/operation_reply_address.go
@@ -10,9 +10,9 @@ import (
 type OperationReplyAddress struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	Location    string `json:"location"`
-	Reference   string `json:"$ref"`
+	Reference   string `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/operation_trait.go
+++ b/pkg/asyncapi/v3/operation_trait.go
@@ -6,14 +6,14 @@ package asyncapiv3
 type OperationTrait struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Title        string                 `json:"title"`
-	Summary      string                 `json:"summary"`
-	Description  string                 `json:"description"`
-	Security     []*SecurityScheme      `json:"security"`
-	Tags         []*Tag                 `json:"tags"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs"`
-	Bindings     *OperationBindings     `json:"bindings"`
-	Reference    string                 `json:"$ref"`
+	Title        string                 `json:"title,omitempty"`
+	Summary      string                 `json:"summary,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Security     []*SecurityScheme      `json:"security,omitempty"`
+	Tags         []*Tag                 `json:"tags,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Bindings     *OperationBindings     `json:"bindings,omitempty"`
+	Reference    string                 `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/parameter.go
+++ b/pkg/asyncapi/v3/parameter.go
@@ -4,12 +4,12 @@ package asyncapiv3
 // from an asyncapi specification that will be used to generate code.
 // Source: https://www.asyncapi.com/docs/reference/specification/v3.0.0#parameterObject
 type Parameter struct {
-	Enum        []string `json:"enum"`
-	Default     string   `json:"default"`
-	Description string   `json:"description"`
-	Examples    []string `json:"examples"`
-	Location    string   `json:"location"`
-	Reference   string   `json:"$ref"`
+	Enum        []string `json:"enum,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Examples    []string `json:"examples,omitempty"`
+	Location    string   `json:"location,omitempty"`
+	Reference   string   `json:"$ref,omitempty"`
 
 	// Non AsyncAPI fields
 	Name        string     `json:"-"`

--- a/pkg/asyncapi/v3/schema.go
+++ b/pkg/asyncapi/v3/schema.go
@@ -30,30 +30,30 @@ const (
 type Schema struct {
 	// --- Original JSON Schema Definition -------------------------------------
 
-	Title                string             `json:"title"`
-	Type                 string             `json:"type"`
-	Examples             []any              `json:"examples"`
-	ReadOnly             bool               `json:"readOnly"`
-	WriteOnly            bool               `json:"writeOnly"`
-	Properties           map[string]*Schema `json:"properties"`
-	PatternProperties    map[string]*Schema `json:"patternProperties"`
-	AdditionalProperties *Schema            `json:"additionalProperties"`
-	AdditionalItems      []*Schema          `json:"additionalItems"`
-	Items                *Schema            `json:"items"`
-	PropertyNames        []string           `json:"propertyNames"`
-	Contains             []*Schema          `json:"contains"`
-	AllOf                []*Schema          `json:"allOf"`
-	AnyOf                []*Schema          `json:"anyOf"`
-	OneOf                []*Schema          `json:"oneOf"`
-	Not                  *Schema            `json:"not"`
+	Title                string             `json:"title,omitempty"`
+	Type                 string             `json:"type,omitempty"`
+	Examples             []any              `json:"examples,omitempty"`
+	ReadOnly             bool               `json:"readOnly,omitempty"`
+	WriteOnly            bool               `json:"writeOnly,omitempty"`
+	Properties           map[string]*Schema `json:"properties,omitempty"`
+	PatternProperties    map[string]*Schema `json:"patternProperties,omitempty"`
+	AdditionalProperties *Schema            `json:"additionalProperties,omitempty"`
+	AdditionalItems      []*Schema          `json:"additionalItems,omitempty"`
+	Items                *Schema            `json:"items,omitempty"`
+	PropertyNames        []string           `json:"propertyNames,omitempty"`
+	Contains             []*Schema          `json:"contains,omitempty"`
+	AllOf                []*Schema          `json:"allOf,omitempty"`
+	AnyOf                []*Schema          `json:"anyOf,omitempty"`
+	OneOf                []*Schema          `json:"oneOf,omitempty"`
+	Not                  *Schema            `json:"not,omitempty"`
 
 	// --- AsyncAPI specific ---------------------------------------------------
 
-	Description string `json:"description"`
-	Format      string `json:"format"`
-	Default     any    `json:"default"`
+	Description string `json:"description,omitempty"`
+	Format      string `json:"format,omitempty"`
+	Default     any    `json:"default,omitempty"`
 
-	Reference string `json:"$ref"`
+	Reference string `json:"$ref,omitempty"`
 
 	// --- Non Json Schema/AsyncAPI fields -------------------------------------
 

--- a/pkg/asyncapi/v3/schema.go
+++ b/pkg/asyncapi/v3/schema.go
@@ -167,7 +167,7 @@ func (s *Schema) generateMetadata(parentName, name string, number *int, isRequir
 }
 
 //
-//nolint:funlen,cyclop // Not necessary to reduce length and cyclop
+//nolint:cyclop // Not necessary to reduce cyclop
 func (s *Schema) setDependencies(spec Specification) error {
 	// Prevent modification if nil
 	if s == nil {

--- a/pkg/asyncapi/v3/security_scheme.go
+++ b/pkg/asyncapi/v3/security_scheme.go
@@ -8,7 +8,7 @@ type OAuthFlow struct {
 
 	AuthorizationURL string            `json:"authorizationUrl"`
 	TokenURL         string            `json:"tokenUrl"`
-	RefreshURL       string            `json:"refreshUrl"`
+	RefreshURL       string            `json:"refreshUrl,omitempty"`
 	AvailableScopes  map[string]string `json:"availableScopes"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
@@ -20,10 +20,10 @@ type OAuthFlow struct {
 type OAuthFlows struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Implicit          OAuthFlow `json:"implicit"`
-	Password          OAuthFlow `json:"password"`
-	ClientCredentials OAuthFlow `json:"clientCredential"`
-	AuthorizationCode OAuthFlow `json:"authorizationCode"`
+	Implicit          OAuthFlow `json:"implicit,omitzero"`
+	Password          OAuthFlow `json:"password,omitzero"`
+	ClientCredentials OAuthFlow `json:"clientCredential,omitzero"`
+	AuthorizationCode OAuthFlow `json:"authorizationCode,omitzero"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 }
@@ -35,20 +35,41 @@ type SecurityScheme struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
 	Type             string     `json:"type"`
-	Description      string     `json:"description"`
-	Name             string     `json:"name"`
-	In               string     `json:"in"`
-	Scheme           string     `json:"scheme"`
-	BearerFormat     string     `json:"bearerFormat"`
-	Flows            OAuthFlows `json:"flows"`
-	OpenIDConnectURL string     `json:"openIdConnectUrl"`
-	Scopes           []string   `json:"scopes"`
-	Reference        string     `json:"$ref"`
+	Description      string     `json:"description,omitempty"`
+	Name             string     `json:"name,omitempty"`
+	In               string     `json:"in,omitempty"`
+	Scheme           string     `json:"scheme,omitempty"`
+	BearerFormat     string     `json:"bearerFormat,omitempty"`
+	Flows            OAuthFlows `json:"flows,omitzero"`
+	OpenIDConnectURL string     `json:"openIdConnectUrl,omitempty"`
+	Scopes           []string   `json:"scopes,omitempty"`
+	Reference        string     `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 
 	ReferenceTo *SecurityScheme `json:"-"`
 }
+
+// SecuritySchemeType is type of a security scheme.
+type SecuritySchemeType string
+
+// Security scheme types supported by the AsyncAPI specification.
+// Source: https://www.asyncapi.com/docs/reference/specification/v3.0.0#securitySchemeObject
+const (
+	SecuritySchemeUserPassword         SecuritySchemeType = "userPassword"
+	SecuritySchemeAPIKey               SecuritySchemeType = "apiKey"
+	SecuritySchemeX509                 SecuritySchemeType = "X509"
+	SecuritySchemeSymmetricEncryption  SecuritySchemeType = "symmetricEncryption"
+	SecuritySchemeASymmetricEncryption SecuritySchemeType = "asymmetricEncryption"
+	SecuritySchemeHTTPAPIKey           SecuritySchemeType = "httpApiKey"
+	SecuritySchemeHTTP                 SecuritySchemeType = "http"
+	SecuritySchemeOAuth2               SecuritySchemeType = "oauth2"
+	SecuritySchemeOpenIDConnect        SecuritySchemeType = "openIdConnect"
+	SecuritySchemePlain                SecuritySchemeType = "plain"
+	SecuritySchemeScramSha256          SecuritySchemeType = "scramSha256"
+	SecuritySchemeScramSha512          SecuritySchemeType = "scramSha512"
+	SecuritySchemeGSSAPI               SecuritySchemeType = "gssapi"
+)
 
 // generateMetadata generates metadata for the SecurityScheme.
 func (s *SecurityScheme) generateMetadata(parentName, name string, number *int) {

--- a/pkg/asyncapi/v3/server.go
+++ b/pkg/asyncapi/v3/server.go
@@ -8,17 +8,17 @@ type Server struct {
 
 	Host            string                     `json:"host"`
 	Protocol        string                     `json:"protocol"`
-	ProtocolVersion string                     `json:"protocolVersion"`
-	PathName        string                     `json:"pathname"`
-	Description     string                     `json:"description"`
-	Title           string                     `json:"title"`
-	Summary         string                     `json:"summary"`
-	Variables       map[string]*ServerVariable `json:"variables"`
-	Security        *SecurityScheme            `json:"security"`
-	Tags            []*Tag                     `json:"tags"`
-	ExternalDocs    *ExternalDocumentation     `json:"externalDocs"`
-	Bindings        *ServerBindings            `json:"bindings"`
-	Reference       string                     `json:"$ref"`
+	ProtocolVersion string                     `json:"protocolVersion,omitempty"`
+	PathName        string                     `json:"pathname,omitempty"`
+	Description     string                     `json:"description,omitempty"`
+	Title           string                     `json:"title,omitempty"`
+	Summary         string                     `json:"summary,omitempty"`
+	Variables       map[string]*ServerVariable `json:"variables,omitempty"`
+	Security        *SecurityScheme            `json:"security,omitempty"`
+	Tags            []*Tag                     `json:"tags,omitempty"`
+	ExternalDocs    *ExternalDocumentation     `json:"externalDocs,omitempty"`
+	Bindings        *ServerBindings            `json:"bindings,omitempty"`
+	Reference       string                     `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/server_bindings.go
+++ b/pkg/asyncapi/v3/server_bindings.go
@@ -6,26 +6,26 @@ package asyncapiv3
 type ServerBindings struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	HTTP         HTTPBinding         `json:"http"`
-	WS           WsBinding           `json:"ws"`
-	Kafka        KafkaBinding        `json:"kafka"`
-	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq"`
-	AMQP         AMQPBinding         `json:"amqp"`
-	AMQP1        AMQP1Binding        `json:"amqp1"`
-	MQTT         MQTTBinding         `json:"mqtt"`
-	MQTT5        MQTT5Binding        `json:"mqtt5"`
-	NATS         NATSBinding         `json:"nats"`
-	JMS          JMSBinding          `json:"jms"`
-	SNS          SNSBinding          `json:"sns"`
-	Solace       SolaceBinding       `json:"solace"`
-	SQS          SQSBinding          `json:"sqs"`
-	Stomp        StompBinding        `json:"stomp"`
-	Redis        RedisBinding        `json:"redis"`
-	Mercure      MercureBinding      `json:"mercure"`
-	IBMMQ        IBMMQBinding        `json:"ibmmq"`
-	GooglePubSub GooglePubSubBinding `json:"googlepubsub"`
-	Pulsar       PulsarBinding       `json:"pulsar"`
-	Reference    string              `json:"$ref"`
+	HTTP         HTTPBinding         `json:"http,omitzero"`
+	WS           WsBinding           `json:"ws,omitzero"`
+	Kafka        KafkaBinding        `json:"kafka,omitzero"`
+	AnyPointMQ   AnyPointMqBinding   `json:"anypointmq,omitzero"`
+	AMQP         AMQPBinding         `json:"amqp,omitzero"`
+	AMQP1        AMQP1Binding        `json:"amqp1,omitzero"`
+	MQTT         MQTTBinding         `json:"mqtt,omitzero"`
+	MQTT5        MQTT5Binding        `json:"mqtt5,omitzero"`
+	NATS         NATSBinding         `json:"nats,omitzero"`
+	JMS          JMSBinding          `json:"jms,omitzero"`
+	SNS          SNSBinding          `json:"sns,omitzero"`
+	Solace       SolaceBinding       `json:"solace,omitzero"`
+	SQS          SQSBinding          `json:"sqs,omitzero"`
+	Stomp        StompBinding        `json:"stomp,omitzero"`
+	Redis        RedisBinding        `json:"redis,omitzero"`
+	Mercure      MercureBinding      `json:"mercure,omitzero"`
+	IBMMQ        IBMMQBinding        `json:"ibmmq,omitzero"`
+	GooglePubSub GooglePubSubBinding `json:"googlepubsub,omitzero"`
+	Pulsar       PulsarBinding       `json:"pulsar,omitzero"`
+	Reference    string              `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/server_variable.go
+++ b/pkg/asyncapi/v3/server_variable.go
@@ -6,11 +6,11 @@ package asyncapiv3
 type ServerVariable struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
-	Enum        []string `json:"enum"`
-	Default     string   `json:"default"`
-	Description string   `json:"description"`
-	Examples    []string `json:"examples"`
-	Reference   string   `json:"$ref"`
+	Enum        []string `json:"enum,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Examples    []string `json:"examples,omitempty"`
+	Reference   string   `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 

--- a/pkg/asyncapi/v3/specification.go
+++ b/pkg/asyncapi/v3/specification.go
@@ -26,19 +26,19 @@ type Specification struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
 	Version            string                `json:"asyncapi"`
-	ID                 string                `json:"id"`
+	ID                 string                `json:"id,omitempty"`
 	Info               Info                  `json:"info"`
-	Servers            map[string]*Server    `json:"servers"`
-	DefaultContentType string                `json:"defaultContentType"`
-	Channels           map[string]*Channel   `json:"channels"`
-	Operations         map[string]*Operation `json:"operations"`
-	Components         Components            `json:"components"`
+	Servers            map[string]*Server    `json:"servers,omitempty"`
+	DefaultContentType string                `json:"defaultContentType,omitempty"`
+	Channels           map[string]*Channel   `json:"channels,omitempty"`
+	Operations         map[string]*Operation `json:"operations,omitempty"`
+	Components         Components            `json:"components,omitzero"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 
 	// specificationReferenced is a map of all the outside specifications that
 	// are referenced in this specification.
-	dependencies map[string]*Specification
+	dependencies map[string]*Specification `json:"-"`
 }
 
 // NewSpecification creates a new Specification struct.

--- a/pkg/asyncapi/v3/tag.go
+++ b/pkg/asyncapi/v3/tag.go
@@ -7,9 +7,9 @@ type Tag struct {
 	// --- AsyncAPI fields -----------------------------------------------------
 
 	Name         string                 `json:"name"`
-	Description  string                 `json:"description"`
-	ExternalDocs *ExternalDocumentation `json:"externalDocs"`
-	Reference    string                 `json:"$ref"`
+	Description  string                 `json:"description,omitempty"`
+	ExternalDocs *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Reference    string                 `json:"$ref,omitempty"`
 
 	// --- Non AsyncAPI fields -------------------------------------------------
 


### PR DESCRIPTION
This PR adds `omitempty` and `omitzero` to the JSON struct tags for any fields that are not required according to the AsyncAPI specification. Some fields required the newer `omitzero` tag to be excluded without changing them to a pointer type, but I used `omitempty` for every other field for maximum backwards compatibility.

There is also a bug fix for the `Operation.Description` field, which was set to use `string` as its name in JSON.

I documented that the `MessageTrait.Payload` field should probably be removed, but kept it for now.

I also documented some nuances with the interpretation of the `Operation.Messages` field.