### PR TITLE
refactor: fix camel case to be true camelCase and add pascal case

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,8 @@ Payload:
 
 Here are the generated JSON sent, given by the different options:
 * No conversion (`none`): `{ "This_is a-Property": "value" }`
-* Camel case (`camel`): `{ "ThisIsAProperty": "value" }`
+* Camel case (`camel`): `{ "thisIsAProperty": "value" }`
+* Pascal case (`pascal`): `{ "ThisIsAProperty": "value" }`
 * Kebab case (`kebab`): `{ "this-is-a-property": "value" }`
 * Snake case (`snake`): `{ "this_is_a_property": "value" }`
 

--- a/cmd/asyncapi-codegen/config.go
+++ b/cmd/asyncapi-codegen/config.go
@@ -34,11 +34,11 @@ type Flags struct {
 	DisableFormatting bool
 
 	// ConvertKeys defines a schema property keys conversion strategy.
-	// Supported values: snake, camel, kebab, none
+	// Supported values: snake, camel, pascal, kebab, none
 	ConvertKeys string
 
 	// NamingScheme defines the naming case for generated golang structs
-	// Supported values: camel, none
+	// Supported values: camel, pascal, none
 	NamingScheme string
 
 	// IgnoreStringFormat states whether the properties' format (date, date-time) should impact the type in types
@@ -58,9 +58,9 @@ func (f *Flags) SetToCommand(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&f.Generate, "generate", "g", "user,application,types", "Generation options")
 	cmd.Flags().BoolVarP(&f.DisableFormatting, "disable-formatting", "f", false, "Disables the code generation formatting")
 	cmd.Flags().StringVarP(&f.ConvertKeys, "convert-keys", "c", "none",
-		"Schema property key names conversion strategy.\nSupported values: snake, camel, kebab, none.")
+		"Schema property key names conversion strategy.\nSupported values: snake, camel, pascal, kebab, none.")
 	cmd.Flags().StringVarP(&f.NamingScheme, "naming-scheme", "n", "none",
-		"Naming scheme for generated golang elements.\nSupported values: camel, none.")
+		"Naming scheme for generated golang elements.\nSupported values: camel, pascal, none.")
 	cmd.Flags().BoolVar(&f.IgnoreStringFormat, "ignore-string-format", false,
 		"Ignores the format (date, date-time) on string properties, generating golang string, instead of dates")
 	cmd.Flags().BoolVar(&f.ForcePointers, "force-pointers", false, "Forces all struct fields to be generated as pointers")

--- a/pkg/codegen/options/options.go
+++ b/pkg/codegen/options/options.go
@@ -26,11 +26,11 @@ type Options struct {
 	DisableFormatting bool
 
 	// ConvertKeys defines a schema property keys conversion strategy.
-	// Supported values: snake, camel, kebab, none
+	// Supported values: snake, camel, pascal, kebab, none
 	ConvertKeys string
 
 	// NamingScheme defines the naming scheme for generated golang structs
-	// Supported values: camel, none
+	// Supported values: camel, pascal, none
 	NamingScheme string
 
 	// IgnoreStringFormat states whether the properties' format (date, date-time) should impact the type in types

--- a/pkg/utils/template/helpers.go
+++ b/pkg/utils/template/helpers.go
@@ -13,16 +13,31 @@ import (
 
 type namingSchemeFn func(string) string
 
+// toLowerCamel converts a string to camelCase (first letter lowercase).
+func toLowerCamel(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	camel := strcase.ToCamel(s)
+	// Lowercase the first letter
+	if len(camel) > 0 {
+		return strings.ToLower(camel[:1]) + camel[1:]
+	}
+	return camel
+}
+
 var convertKeyFuncs = map[string]namingSchemeFn{
-	"snake": strcase.ToSnake,
-	"kebab": strcase.ToKebab,
-	"camel": strcase.ToCamel,
-	"none":  func(s string) string { return s },
+	"snake":  strcase.ToSnake,
+	"kebab":  strcase.ToKebab,
+	"camel":  toLowerCamel,
+	"pascal": strcase.ToCamel,
+	"none":   func(s string) string { return s },
 }
 
 var namifyPerScheme = map[string]namingSchemeFn{
-	"camel": strcase.ToCamel,
-	"none":  DefaultNamifier,
+	"camel":  toLowerCamel,
+	"pascal": strcase.ToCamel,
+	"none":   DefaultNamifier,
 }
 
 var convertKey = convertKeyFuncs["none"]
@@ -87,7 +102,7 @@ func Namify(sentence string) string {
 func SetConvertKeyFn(name string) error {
 	fn, ok := convertKeyFuncs[name]
 	if !ok {
-		return fmt.Errorf("unknown convert key function %s, supported values: snake, kebab, camel, none", name)
+		return fmt.Errorf("unknown convert key function %s, supported values: snake, kebab, camel, pascal, none", name)
 	}
 
 	convertKey = fn
@@ -99,7 +114,7 @@ func SetConvertKeyFn(name string) error {
 func SetNamifyFn(name string) error {
 	fn, ok := namifyPerScheme[name]
 	if !ok {
-		return fmt.Errorf("unknown namify function %s, supported values: camel, none", name)
+		return fmt.Errorf("unknown namify function %s, supported values: camel, pascal, none", name)
 	}
 
 	namify = fn

--- a/test/v2/issues/129/camel/asyncapi.gen.go
+++ b/test/v2/issues/129/camel/asyncapi.gen.go
@@ -242,7 +242,7 @@ func (msg V2Issue129TestMessage) toBrokerMessage() (extensions.BrokerMessage, er
 
 // TestSchema is a schema from the AsyncAPI specification required in messages
 type TestSchema struct {
-	ThisIsAProperty *string `json:"ThisIsAProperty,omitempty"`
+	ThisIsAProperty *string `json:"thisIsAProperty,omitempty"`
 }
 
 const (

--- a/test/v2/issues/129/suite_test.go
+++ b/test/v2/issues/129/suite_test.go
@@ -142,5 +142,5 @@ func (suite *Suite) TestWithCamelKeyConversion() {
 	bMsg := <-interceptor
 
 	// Check that the additional properties are at the level 0 of payload
-	suite.Require().Equal("{\"ThisIsAProperty\":\"value\"}", string(bMsg.Payload))
+	suite.Require().Equal("{\"thisIsAProperty\":\"value\"}", string(bMsg.Payload))
 }

--- a/test/v2/issues/220/suite_test.go
+++ b/test/v2/issues/220/suite_test.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../../../cmd/asyncapi-codegen -p camel -n camel -i ./asyncapi.yaml -o ./camel/asyncapi.gen.go
+//go:generate go run ../../../../cmd/asyncapi-codegen -p camel -n pascal -i ./asyncapi.yaml -o ./camel/asyncapi.gen.go
 //go:generate go run ../../../../cmd/asyncapi-codegen -p none -n none -i ./asyncapi.yaml -o ./none/asyncapi.gen.go
 
 package issue220

--- a/test/v3/issues/129/camel/asyncapi.gen.go
+++ b/test/v3/issues/129/camel/asyncapi.gen.go
@@ -245,7 +245,7 @@ func (msg TestMessageFromTestChannel) toBrokerMessage() (extensions.BrokerMessag
 
 // TestSchema is a schema from the AsyncAPI specification required in messages
 type TestSchema struct {
-	ThisIsAProperty *string `json:"ThisIsAProperty,omitempty"`
+	ThisIsAProperty *string `json:"thisIsAProperty,omitempty"`
 }
 
 const (

--- a/test/v3/issues/129/suite_test.go
+++ b/test/v3/issues/129/suite_test.go
@@ -142,5 +142,5 @@ func (suite *Suite) TestWithCamelKeyConversion() {
 	bMsg := <-interceptor
 
 	// Check that the additional properties are at the level 0 of payload
-	suite.Require().Equal("{\"ThisIsAProperty\":\"value\"}", string(bMsg.Payload))
+	suite.Require().Equal("{\"thisIsAProperty\":\"value\"}", string(bMsg.Payload))
 }

--- a/test/v3/issues/220/suite_test.go
+++ b/test/v3/issues/220/suite_test.go
@@ -1,4 +1,4 @@
-//go:generate go run ../../../../cmd/asyncapi-codegen -p camel -n camel -i ./asyncapi.yaml -o ./camel/asyncapi.gen.go
+//go:generate go run ../../../../cmd/asyncapi-codegen -p camel -n pascal -i ./asyncapi.yaml -o ./camel/asyncapi.gen.go
 //go:generate go run ../../../../cmd/asyncapi-codegen -p none -n none -i ./asyncapi.yaml -o ./none/asyncapi.gen.go
 
 package issue220


### PR DESCRIPTION
This PR refactors the naming conventions:

- **Camel case (`camel`)**: Now produces true camelCase with lowercase first letter (e.g., `thisIsAProperty`)
- **Pascal case (`pascal`)**: New option that produces PascalCase with uppercase first letter (e.g., `ThisIsAProperty`) - this was the old camel behavior
- Updated all documentation and error messages to include the new pascal option
- Updated test files to use pascal naming scheme for struct names (since Go structs need to be exported)

The changes ensure that:
- JSON property keys can use true camelCase via `--convert-keys camel`
- Struct names can use PascalCase via `--naming-scheme pascal` (required for exported Go types)
- Backward compatibility: users who want the old camel behavior should use `pascal` instead