### PR TITLE
fix: address code-review findings across codegen, parser and brokers

### DIFF
--- a/build/ci/dagger/brokers.go
+++ b/build/ci/dagger/brokers.go
@@ -9,7 +9,9 @@ import (
 
 const (
 	// kafkaImage is the image used for kafka.
-	kafkaImage = "bitnami/kafka:3.5.1"
+	// NOTE: Bitnami deprecated their public Docker Hub catalog, so the image now
+	// lives under the bitnamilegacy organization (same image, relocated).
+	kafkaImage = "bitnamilegacy/kafka:3.5.1"
 	// natsImage is the image used for NATS.
 	natsImage = "nats:2.10"
 )

--- a/cmd/asyncapi-codegen/config.go
+++ b/cmd/asyncapi-codegen/config.go
@@ -29,9 +29,6 @@ type Flags struct {
 	// golang code should be generated
 	Generate string
 
-	// Broker contains the broker name whose code should be generated
-	Broker string
-
 	// DisableFormatting states if the formatting should be disabled when
 	// writing the generated code
 	DisableFormatting bool

--- a/cmd/asyncapi-codegen/main.go
+++ b/cmd/asyncapi-codegen/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -19,6 +20,10 @@ Just plug your application to your favorite message broker!
 More info on README: https://github.com/lerenn/asyncapi-codegen
 `,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		if len(flags.InputPaths) == 0 {
+			return errors.New("at least one input path is required (--input)")
+		}
+
 		cg, err := codegen.FromFile(flags.InputPaths[0], flags.InputPaths[1:]...)
 		if err != nil {
 			return err

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
 
   # Kafka variants
   kafka:
-    image: bitnami/kafka:3.5.1
+    image: bitnamilegacy/kafka:3.5.1
     ports:
       - 9092:9092
       - 9093:9093
@@ -95,7 +95,7 @@ services:
       - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
       - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INTERNAL
   kafka-tls:
-    image: bitnami/kafka:3.5.1
+    image: bitnamilegacy/kafka:3.5.1
     ports:
       - 9094:9094
       - 9095:9095
@@ -116,7 +116,7 @@ services:
     volumes:
       - ./tmp/certs/kafka:/bitnami/kafka/config/certs/
   kafka-tls-basic-auth:
-    image: bitnami/kafka:3.5.1
+    image: bitnamilegacy/kafka:3.5.1
     ports:
       - 9096:9096
       - 9097:9097

--- a/pkg/asyncapi/parser/parse.go
+++ b/pkg/asyncapi/parser/parse.go
@@ -58,7 +58,7 @@ func FromFile(params FromFileParams) (asyncapi.Specification, error) {
 			MajorVersion: params.MajorVersion,
 		})
 	default:
-		return nil, fmt.Errorf("%w: %q", ErrInvalidFileFormat, params.MajorVersion)
+		return nil, fmt.Errorf("%w: unsupported file extension %q", ErrInvalidFileFormat, filepath.Ext(params.Path))
 	}
 }
 
@@ -128,7 +128,7 @@ func FromJSON(params FromJSONParams) (asyncapi.Specification, error) {
 	case 3:
 		spec = asyncapiv3.NewSpecification()
 	default:
-		return nil, fmt.Errorf("unknown version (%q): this should not have happened", majorVersion)
+		return nil, fmt.Errorf("unknown version (%d): this should not have happened", majorVersion)
 	}
 
 	// Parse JSON

--- a/pkg/asyncapi/v3/message.go
+++ b/pkg/asyncapi/v3/message.go
@@ -592,7 +592,7 @@ func (msg *Message) mergePayload(spec Specification, payload *Schema) error {
 	}
 
 	// Merge payload
-	return msg.Headers.MergeWith(spec, *payload)
+	return msg.Payload.MergeWith(spec, *payload)
 }
 
 // HaveCorrelationID check that the message have a correlation ID.

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -93,10 +93,8 @@ func (cg CodeGen) Generate(opt options.Options) error {
 	if opt.IgnoreStringFormat {
 		template.DisableDateOrTimeGeneration()
 	}
-	if opt.ForcePointers {
-		templatesv2.ForcePointerOnFields()
-		templatesv3.ForcePointerOnFields()
-	}
+	templatesv2.SetForcePointers(opt.ForcePointers)
+	templatesv3.SetForcePointers(opt.ForcePointers)
 
 	// Process Specification
 	if err := cg.Specification.Process(); err != nil {
@@ -157,6 +155,6 @@ func (cg CodeGen) generateContent(opt options.Options) (string, error) {
 			ModuleVersion: cg.moduleVersion,
 		}.Generate()
 	default:
-		return "", fmt.Errorf("unsupported major version (%q)", version)
+		return "", fmt.Errorf("unsupported major version (%d)", version)
 	}
 }

--- a/pkg/codegen/generators/v2/templates/helpers.go
+++ b/pkg/codegen/generators/v2/templates/helpers.go
@@ -68,34 +68,37 @@ func ReferenceToStructAttributePath(ref string) string {
 
 // ReferenceToTypeName will convert a reference to a type name in the form of
 // golang conventional type names.
-func ReferenceToTypeName(ref string) string {
+func ReferenceToTypeName(ref string) (string, error) {
 	parts := strings.Split(ref, "/")
-	return templateutil.Namify(parts[3])
+	if len(parts) < 4 {
+		return "", fmt.Errorf("invalid reference %q: expected at least 4 '/'-separated segments", ref)
+	}
+	return templateutil.Namify(parts[3]), nil
 }
 
 // ChannelToMessage will convert a channel to its message, based on publish/subscribe.
 //
 //nolint:cyclop
-func ChannelToMessage(ch asyncapi.Channel, direction string) *asyncapi.Message {
+func ChannelToMessage(ch asyncapi.Channel, direction string) (*asyncapi.Message, error) {
 	switch {
 	case ch.Publish != nil && ch.Subscribe == nil:
-		return ch.Publish.Message.Follow()
+		return ch.Publish.Message.Follow(), nil
 	case ch.Subscribe != nil && ch.Publish == nil:
-		return ch.Subscribe.Message.Follow()
+		return ch.Subscribe.Message.Follow(), nil
 	case direction == "publish":
 		if ch.Publish == nil {
-			panic("ChannelToMessage: channel has no publish operation")
+			return nil, fmt.Errorf("channel %q has no publish operation", ch.Name)
 		}
-		return ch.Publish.Message.Follow()
+		return ch.Publish.Message.Follow(), nil
 	case direction == "subscribe":
 		if ch.Subscribe == nil {
-			panic("ChannelToMessage: channel has no subscribe operation")
+			return nil, fmt.Errorf("channel %q has no subscribe operation", ch.Name)
 		}
-		return ch.Subscribe.Message.Follow()
+		return ch.Subscribe.Message.Follow(), nil
 	case ch.Subscribe == nil && ch.Publish == nil:
-		panic("ChannelToMessage: channel has no publish or subscribe operation")
+		return nil, fmt.Errorf("channel %q has no publish or subscribe operation", ch.Name)
 	default:
-		panic("direction must be either 'publish' or 'subscribe'")
+		return nil, fmt.Errorf("direction must be either 'publish' or 'subscribe', got %q", direction)
 	}
 }
 
@@ -114,6 +117,9 @@ func GenerateChannelPath(ch asyncapi.Channel) string {
 	parameterRegexp := regexp.MustCompile("{[^{}]*}")
 
 	matches := parameterRegexp.FindAllString(ch.Path, -1)
+	if len(matches) == 0 {
+		return fmt.Sprintf("%q", ch.Path)
+	}
 	format := parameterRegexp.ReplaceAllString(ch.Path, "%v")
 
 	sprint := fmt.Sprintf("fmt.Sprintf(%q, ", format)
@@ -141,15 +147,23 @@ func OperationName(channel asyncapi.Channel) string {
 	return templateutil.Namify(name)
 }
 
-var isFieldPointer = func(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
+func defaultIsFieldPointer(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
 	return !(IsRequired(parent, field) || schema.IsRequired) && schema.Type != "array"
 }
 
-// ForcePointerOnFields is used to force the generation of all fields as pointers, except for arrays.
-func ForcePointerOnFields() {
-	isFieldPointer = func(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
-		return schema.Type != "array"
+var isFieldPointer = defaultIsFieldPointer
+
+// SetForcePointers configures whether all struct fields (except arrays) should be
+// generated as pointers. It is reset on every generation run so the setting does
+// not leak between successive generations sharing the same process.
+func SetForcePointers(force bool) {
+	if force {
+		isFieldPointer = func(_ asyncapi.Schema, _ string, schema asyncapi.Schema) bool {
+			return schema.Type != "array"
+		}
+		return
 	}
+	isFieldPointer = defaultIsFieldPointer
 }
 
 // HelpersFunctions returns the functions that can be used as helpers

--- a/pkg/codegen/generators/v3/templates/helpers.go
+++ b/pkg/codegen/generators/v3/templates/helpers.go
@@ -68,22 +68,22 @@ func ReferenceToStructAttributePath(ref string) string {
 
 // ChannelToMessageTypeName will convert a channel to a message type name in the
 // form of golang conventional type names.
-func ChannelToMessageTypeName(ch asyncapi.Channel) string {
+func ChannelToMessageTypeName(ch asyncapi.Channel) (string, error) {
 	msg, err := ch.Follow().GetMessage()
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return templateutil.Namify(msg.Follow().Name)
+	return templateutil.Namify(msg.Follow().Name), nil
 }
 
 // OpToMsgTypeName will convert an operation to a message type name in the
 // form of golang conventional type names.
-func OpToMsgTypeName(op asyncapi.Operation) string {
+func OpToMsgTypeName(op asyncapi.Operation) (string, error) {
 	msg, err := op.Follow().GetMessage()
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return templateutil.Namify(msg.Follow().Name)
+	return templateutil.Namify(msg.Follow().Name), nil
 }
 
 // OpToChannelTypeName will convert an operation to a channel type name in the
@@ -117,6 +117,9 @@ func GenerateChannelAddr(ch *asyncapi.Channel) string {
 	parameterRegexp := regexp.MustCompile("{[^{}]*}")
 
 	matches := parameterRegexp.FindAllString(ch.Address, -1)
+	if len(matches) == 0 {
+		return fmt.Sprintf("%q", ch.Address)
+	}
 	format := parameterRegexp.ReplaceAllString(ch.Address, "%s")
 
 	sprint := fmt.Sprintf("fmt.Sprintf(%q, ", format)
@@ -127,15 +130,23 @@ func GenerateChannelAddr(ch *asyncapi.Channel) string {
 	return sprint[:len(sprint)-1] + ")"
 }
 
-var isFieldPointer = func(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
+func defaultIsFieldPointer(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
 	return !(IsRequired(parent, field) || schema.IsRequired) && schema.Type != "array"
 }
 
-// ForcePointerOnFields is used to force the generation of all fields as pointers, except for arrays.
-func ForcePointerOnFields() {
-	isFieldPointer = func(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
-		return schema.Type != "array"
+var isFieldPointer = defaultIsFieldPointer
+
+// SetForcePointers configures whether all struct fields (except arrays) should be
+// generated as pointers. It is reset on every generation run so the setting does
+// not leak between successive generations sharing the same process.
+func SetForcePointers(force bool) {
+	if force {
+		isFieldPointer = func(_ asyncapi.Schema, _ string, schema asyncapi.Schema) bool {
+			return schema.Type != "array"
+		}
+		return
 	}
+	isFieldPointer = defaultIsFieldPointer
 }
 
 // HelpersFunctions returns the functions that can be used as helpers

--- a/pkg/extensions/broker.go
+++ b/pkg/extensions/broker.go
@@ -3,6 +3,7 @@ package extensions
 import (
 	"context"
 	"fmt"
+	"sync"
 )
 
 // BrokerChannelSubscription is a struct that contains every returned structures
@@ -102,7 +103,11 @@ func (bm BrokerMessage) String() string {
 type AcknowledgeableBrokerMessage struct {
 	BrokerMessage
 
-	acked          bool
+	// ackOnce guarantees that only one acknowledgement (Ack or Nak) is ever
+	// sent to the broker, even when the message is copied (it travels through
+	// channels by value) or when Ack/Nak are called concurrently. It is a
+	// pointer so every copy shares the same underlying sync.Once.
+	ackOnce        *sync.Once
 	acknowledgment BrokerAcknowledgment
 }
 
@@ -112,25 +117,29 @@ func NewAcknowledgeableBrokerMessage(
 	bm BrokerMessage,
 	acknowledgment BrokerAcknowledgment,
 ) AcknowledgeableBrokerMessage {
-	return AcknowledgeableBrokerMessage{BrokerMessage: bm, acknowledgment: acknowledgment}
+	return AcknowledgeableBrokerMessage{
+		BrokerMessage:  bm,
+		ackOnce:        &sync.Once{},
+		acknowledgment: acknowledgment,
+	}
 }
 
 // Ack will call the AckMessage of the underlying BrokerAcknowledgment
-// implementation if the message was not already acked.
+// implementation if the message was not already acknowledged.
 func (bm *AcknowledgeableBrokerMessage) Ack() {
-	if !bm.acked {
-		bm.acknowledgment.AckMessage()
-		bm.acked = true
+	if bm.ackOnce == nil {
+		return
 	}
+	bm.ackOnce.Do(bm.acknowledgment.AckMessage)
 }
 
 // Nak will call the NakMessage of the underlying BrokerAcknowledgment
-// implementation if the message was not already acked.
+// implementation if the message was not already acknowledged.
 func (bm *AcknowledgeableBrokerMessage) Nak() {
-	if !bm.acked {
-		bm.acknowledgment.NakMessage()
-		bm.acked = true
+	if bm.ackOnce == nil {
+		return
 	}
+	bm.ackOnce.Do(bm.acknowledgment.NakMessage)
 }
 
 // BrokerController represents the functions that should be implemented to connect

--- a/pkg/extensions/brokers/natsjetstream/natsjetstream.go
+++ b/pkg/extensions/brokers/natsjetstream/natsjetstream.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/lerenn/asyncapi-codegen/pkg/extensions"
@@ -25,12 +26,28 @@ type Controller struct {
 	logger         extensions.Logger
 	streamName     string
 	consumerName   string
-	consumeContext jetstream.ConsumeContext
-	channels       map[string]chan jetstream.Msg
 	streamConfig   *jetstream.StreamConfig
 	consumerConfig *jetstream.ConsumerConfig
 
+	// mutex guards consumeContext and channels, which are accessed concurrently
+	// from Subscribe, the subscription cancellation handlers and the NATS
+	// consumer callback (ConsumeMessage).
+	mutex          sync.Mutex
+	consumeContext jetstream.ConsumeContext
+	channels       map[string]*subscriptionChannel
+
 	nakDelay time.Duration
+}
+
+// subscriptionChannel holds the channel used to dispatch incoming NATS messages
+// to a subscription's listening goroutine, along with a stop channel that is
+// closed on cancellation. The message channel is intentionally never closed:
+// closing it would race with the consumer callback still trying to send,
+// causing a "send on closed channel" panic. Instead, both the listener and the
+// producer select on stop to unwind cleanly.
+type subscriptionChannel struct {
+	messages chan jetstream.Msg
+	stop     chan struct{}
 }
 
 // NewController creates a new NATS JetStream controller.
@@ -39,7 +56,7 @@ func NewController(url string, options ...ControllerOption) (*Controller, error)
 	controller := &Controller{
 		url:            url,
 		logger:         extensions.DummyLogger{},
-		channels:       make(map[string]chan jetstream.Msg),
+		channels:       make(map[string]*subscriptionChannel),
 		consumeContext: nil,
 		nakDelay:       time.Second * 5,
 	}
@@ -230,27 +247,54 @@ func (c *Controller) Subscribe(ctx context.Context, channel string) (extensions.
 		make(chan any, 1),
 	)
 
-	if c.channels[channel] == nil {
-		c.channels[channel] = make(chan jetstream.Msg)
+	// Get or create the subscription channel for this NATS subject.
+	c.mutex.Lock()
+	sc := c.channels[channel]
+	if sc == nil {
+		sc = &subscriptionChannel{
+			messages: make(chan jetstream.Msg),
+			stop:     make(chan struct{}),
+		}
+		c.channels[channel] = sc
 	}
+	c.mutex.Unlock()
+
 	if err := c.ConsumeIfNeeded(ctx); err != nil {
+		// Roll back the channel we may have just registered to avoid leaking it.
+		c.mutex.Lock()
+		if c.channels[channel] == sc {
+			delete(c.channels, channel)
+		}
+		c.mutex.Unlock()
 		return extensions.BrokerChannelSubscription{}, err
 	}
 
 	go func() {
-		for message := range c.channels[channel] {
-			c.logger.Info(ctx, fmt.Sprintf("Received message for %s", channel), extensions.LogInfo{
-				Key:   "message",
-				Value: message,
-			})
-			c.HandleMessage(ctx, message, sub)
+		for {
+			select {
+			case <-sc.stop:
+				return
+			case message := <-sc.messages:
+				c.logger.Info(ctx, fmt.Sprintf("Received message for %s", channel), extensions.LogInfo{
+					Key:   "message",
+					Value: message,
+				})
+				c.HandleMessage(ctx, message, sub)
+			}
 		}
 	}()
 
 	// Wait for cancellation and drain the NATS subscription
 	sub.WaitForCancellationAsync(func() {
-		close(c.channels[channel])
-		delete(c.channels, channel)
+		c.mutex.Lock()
+		if c.channels[channel] == sc {
+			delete(c.channels, channel)
+		}
+		c.mutex.Unlock()
+
+		// Stop the listener goroutine and unblock any in-flight producer.
+		close(sc.stop)
+
 		c.StopConsumeIfNeeded()
 	})
 
@@ -296,23 +340,31 @@ func (c *Controller) Close() {
 
 // ConsumeIfNeeded starts consuming messages if needed.
 func (c *Controller) ConsumeIfNeeded(ctx context.Context) error {
-	if c.consumeContext == nil {
-		consumer, err := c.jetStream.Consumer(ctx, c.streamName, c.consumerName)
-		if err != nil {
-			return err
-		}
-		consumeContext, err := consumer.Consume(c.ConsumeMessage(ctx))
-		if err != nil {
-			return err
-		}
-		c.consumeContext = consumeContext
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.consumeContext != nil {
+		return nil
 	}
+
+	consumer, err := c.jetStream.Consumer(ctx, c.streamName, c.consumerName)
+	if err != nil {
+		return err
+	}
+	consumeContext, err := consumer.Consume(c.ConsumeMessage(ctx))
+	if err != nil {
+		return err
+	}
+	c.consumeContext = consumeContext
 
 	return nil
 }
 
 // StopConsumeIfNeeded stops consuming messages if needed (there is no other subscription).
 func (c *Controller) StopConsumeIfNeeded() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	if len(c.channels) == 0 && c.consumeContext != nil {
 		c.consumeContext.Stop()
 		c.consumeContext = nil
@@ -324,14 +376,19 @@ func (c *Controller) StopConsumeIfNeeded() {
 func (c *Controller) ConsumeMessage(ctx context.Context) jetstream.MessageHandler {
 	return func(msg jetstream.Msg) {
 		msgSubj := msg.Subject() // pull this into a var for debuggability
-		var responsibleSubscription string
-		for subjectSubscriptionPattern := range c.channels {
+
+		// Find the subscription responsible for this subject.
+		c.mutex.Lock()
+		var target *subscriptionChannel
+		for subjectSubscriptionPattern, sc := range c.channels {
 			if MatchSubjectSubscription(subjectSubscriptionPattern, msgSubj) {
-				responsibleSubscription = subjectSubscriptionPattern
+				target = sc
 				break
 			}
 		}
-		if responsibleSubscription == "" {
+		c.mutex.Unlock()
+
+		if target == nil {
 			c.logger.Warning(
 				ctx,
 				fmt.Sprintf(
@@ -346,7 +403,15 @@ func (c *Controller) ConsumeMessage(ctx context.Context) jetstream.MessageHandle
 
 			return
 		}
-		c.channels[responsibleSubscription] <- msg
+
+		// Dispatch the message, but bail out (and ack) if the subscription was
+		// cancelled concurrently so we never block forever or send on a channel
+		// nobody reads anymore.
+		select {
+		case target.messages <- msg:
+		case <-target.stop:
+			_ = msg.Ack()
+		}
 	}
 }
 

--- a/pkg/utils/slice.go
+++ b/pkg/utils/slice.go
@@ -1,5 +1,7 @@
 package utils
 
+import "slices"
+
 // RemoveDuplicateFromSlice removes duplicate values from a slice.
 func RemoveDuplicateFromSlice[T string | int](sliceList []T) []T {
 	allKeys := make(map[T]bool)
@@ -15,10 +17,5 @@ func RemoveDuplicateFromSlice[T string | int](sliceList []T) []T {
 
 // IsInSlice checks if a string is in a slice.
 func IsInSlice(slice []string, match string) bool {
-	for _, v := range slice {
-		if v == match {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, match)
 }

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -4,6 +4,9 @@ import "unicode"
 
 // UpperFirstLetter returns the given string with the first letter in uppercase.
 func UpperFirstLetter(str string) string {
+	if str == "" {
+		return str
+	}
 	r := []rune(str)
 	r[0] = unicode.ToUpper(r[0])
 	return string(r)


### PR DESCRIPTION
Addresses a set of code-review findings, each verified against the source (false positives from the initial sweep were discarded).

## Correctness
- **v3 message merge** targeted `msg.Headers` instead of `msg.Payload`, silently dropping the payload merge when a message already had a payload.
- **parser** reported the integer major-version (and used `%q` on ints) instead of the offending file extension in invalid-format errors.

## Concurrency
- **natsjetstream**: `channels`/`consumeContext` were read, iterated, written and deleted across three goroutines (`Subscribe`, the consumer callback, cancellation) with no synchronization — a real data race plus a "send on closed channel" panic window. Added a mutex and a per-subscription `stop` channel so the data channel is never closed under a concurrent send; also fixed the leak when `ConsumeIfNeeded` fails.
- **broker**: `AcknowledgeableBrokerMessage` now uses a shared `sync.Once` so `Ack`/`Nak` send exactly one acknowledgement even across value copies and concurrent calls.

## Robustness / design
- Template helpers return errors instead of `panic` on malformed specs, bounds-check reference splits, and guard zero-parameter addresses.
- Replaced the sticky one-way `ForcePointerOnFields()` global mutator with `SetForcePointers(bool)`, reset every run so the setting no longer leaks between generations in the same process.

## Cleanups
- `UpperFirstLetter` no longer panics on empty input; `IsInSlice` backed by `slices.Contains`; removed the dead `Broker` CLI flag field; guarded empty `InputPaths`.

## Verification
`go build`, `go vet`, race build, unit tests, and golangci-lint all clean. `go generate ./...` reproduces every generated file byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)