### PR TITLE
ci: migrate Kafka test brokers from Bitnami to apache/kafka

### DIFF
--- a/build/ci/dagger/brokers.go
+++ b/build/ci/dagger/brokers.go
@@ -9,9 +9,10 @@ import (
 
 const (
 	// kafkaImage is the image used for kafka.
-	// NOTE: Bitnami deprecated their public Docker Hub catalog, so the image now
-	// lives under the bitnamilegacy organization (same image, relocated).
-	kafkaImage = "bitnamilegacy/kafka:3.5.1"
+	// NOTE: the official Apache Kafka image is used (the Bitnami catalog was
+	// deprecated). It maps KAFKA_<PROPERTY> environment variables directly to
+	// server.properties.
+	kafkaImage = "apache/kafka:3.9.0"
 	// natsImage is the image used for NATS.
 	natsImage = "nats:2.10"
 )
@@ -50,113 +51,110 @@ func brokerServices() map[string]*dagger.Service {
 	return brokers
 }
 
+// kafkaSingleNodeEnv applies the environment variables shared by every Kafka
+// broker: a single combined controller/broker node with replication factors set
+// to 1 so the internal topics can be created on a one-node cluster.
+func kafkaSingleNodeEnv(c *dagger.Container, advertisedHost, protocolMap string) *dagger.Container {
+	return c.
+		WithEnvVariable("KAFKA_NODE_ID", "0").
+		WithEnvVariable("KAFKA_PROCESS_ROLES", "controller,broker").
+		WithEnvVariable("KAFKA_LISTENERS", "INTERNAL://:9092,CONTROLLER://:9093").
+		WithEnvVariable("KAFKA_ADVERTISED_LISTENERS", "INTERNAL://"+advertisedHost+":9092").
+		WithEnvVariable("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", protocolMap).
+		WithEnvVariable("KAFKA_CONTROLLER_QUORUM_VOTERS", "0@localhost:9093").
+		WithEnvVariable("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
+		WithEnvVariable("KAFKA_INTER_BROKER_LISTENER_NAME", "INTERNAL").
+		WithEnvVariable("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1").
+		WithEnvVariable("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1").
+		WithEnvVariable("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1").
+		WithEnvVariable("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+}
+
+// kafkaTLSDirectory builds the PEM material expected by the Apache Kafka image:
+// a combined keystore (certificate chain + private key in a single file) and a
+// CA truststore so the broker trusts its own certificate over SSL/SASL_SSL.
+func kafkaTLSDirectory(host string) *dagger.Directory {
+	key, cert, cacert, err := testutil.GenerateSelfSignedCertificateWithCA(host)
+	if err != nil {
+		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
+	}
+
+	return dag.Directory().
+		WithNewFile("kafka.keystore.combined.pem", string(cert)+string(key)).
+		WithNewFile("kafka.truststore.pem", string(cacert))
+}
+
 // brokerKafka returns a container for the Kafka broker.
 func brokerKafka() *dagger.Container {
-	return dag.Container().
-		//	Set container image
-		From(kafkaImage).
-
-		// Add environment variables
-		WithEnvVariable("KAFKA_CFG_NODE_ID", "0").
-		WithEnvVariable("KAFKA_CFG_PROCESS_ROLES", "controller,broker").
-		WithEnvVariable("KAFKA_CFG_LISTENERS", "INTERNAL://:9092,CONTROLLER://:9093").
-		WithEnvVariable("KAFKA_CFG_ADVERTISED_LISTENERS", "INTERNAL://kafka:9092").
-		WithEnvVariable("KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP",
-			"CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT").
-		WithEnvVariable("KAFKA_CFG_CONTROLLER_QUORUM_VOTERS", "0@:9093").
-		WithEnvVariable("KAFKA_CFG_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-		WithEnvVariable("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "INTERNAL").
-
-		// Add exposed ports
+	c := dag.Container().From(kafkaImage)
+	c = kafkaSingleNodeEnv(c, "kafka", "CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT")
+	return c.
 		WithExposedPort(9092).
 		WithExposedPort(9093)
 }
 
 // brokerKafkaSecure returns a container for the Kafka broker secured with TLS.
 func brokerKafkaSecure() *dagger.Container {
-	key, cert, cacert, err := testutil.GenerateSelfSignedCertificateWithCA("kafka-tls")
-	if err != nil {
-		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
-	}
-
-	tlsDir := dag.Directory().
-		WithNewFile("kafka.keystore.key", string(key)).
-		WithNewFile("kafka.keystore.pem", string(cert)).
-		WithNewFile("kafka.truststore.pem", string(cacert))
-
-	return dag.Container().
-		//	Set container image
-		From(kafkaImage).
-
-		// Add environment variables
-		WithEnvVariable("KAFKA_CFG_NODE_ID", "0").
-		WithEnvVariable("KAFKA_CFG_PROCESS_ROLES", "controller,broker").
-		WithEnvVariable("KAFKA_CFG_LISTENERS", "INTERNAL://:9092,CONTROLLER://:9093").
-		WithEnvVariable("KAFKA_CFG_ADVERTISED_LISTENERS", "INTERNAL://kafka-tls:9092").
-		WithEnvVariable("KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP",
-			"CONTROLLER:PLAINTEXT,INTERNAL:SSL").
-		WithEnvVariable("KAFKA_CFG_CONTROLLER_QUORUM_VOTERS", "0@:9093").
-		WithEnvVariable("KAFKA_CFG_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-		WithEnvVariable("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "INTERNAL").
-
-		// Add tls config
-		WithEnvVariable("KAFKA_TLS_TYPE", "PEM").
-		// disable client cert
-		WithEnvVariable("KAFKA_TLS_CLIENT_AUTH", "none").
-
-		// Add exposed ports
+	c := dag.Container().From(kafkaImage)
+	c = kafkaSingleNodeEnv(c, "kafka-tls", "CONTROLLER:PLAINTEXT,INTERNAL:SSL")
+	return c.
+		// PEM keystore + CA truststore, client certificate auth disabled.
+		WithEnvVariable("KAFKA_SSL_KEYSTORE_TYPE", "PEM").
+		WithEnvVariable("KAFKA_SSL_KEYSTORE_LOCATION", "/etc/kafka/secrets/kafka.keystore.combined.pem").
+		WithEnvVariable("KAFKA_SSL_TRUSTSTORE_TYPE", "PEM").
+		WithEnvVariable("KAFKA_SSL_TRUSTSTORE_LOCATION", "/etc/kafka/secrets/kafka.truststore.pem").
+		WithEnvVariable("KAFKA_SSL_CLIENT_AUTH", "none").
 		WithExposedPort(9092).
 		WithExposedPort(9093).
-
-		// Add server cert and key directory
-		WithDirectory("/bitnami/kafka/config/certs/", tlsDir)
+		WithDirectory("/etc/kafka/secrets", kafkaTLSDirectory("kafka-tls"))
 }
+
+// kafkaSASLProperties is the server.properties used by the SASL_SSL broker. The
+// SCRAM credentials must be present in the KRaft metadata log, which is only
+// possible at format time via `--add-scram` (see brokerKafkaSecureBasicAuth).
+const kafkaSASLProperties = `node.id=0
+process.roles=controller,broker
+listeners=INTERNAL://:9092,CONTROLLER://:9093
+advertised.listeners=INTERNAL://kafka-tls-basic-auth:9092
+listener.security.protocol.map=CONTROLLER:PLAINTEXT,INTERNAL:SASL_SSL
+controller.quorum.voters=0@localhost:9093
+controller.listener.names=CONTROLLER
+inter.broker.listener.name=INTERNAL
+log.dirs=/tmp/kraft-combined-logs
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+group.initial.rebalance.delay.ms=0
+sasl.enabled.mechanisms=SCRAM-SHA-512
+sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
+listener.name.internal.sasl.enabled.mechanisms=SCRAM-SHA-512
+listener.name.internal.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="user" password="password";
+ssl.keystore.type=PEM
+ssl.keystore.location=/etc/kafka/secrets/kafka.keystore.combined.pem
+ssl.truststore.type=PEM
+ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.pem
+ssl.client.auth=none
+`
 
 // brokerKafkaSecureBasicAuth returns a container for the Kafka broker secured with TLS and basic auth.
 func brokerKafkaSecureBasicAuth() *dagger.Container {
-	key, cert, cacert, err := testutil.GenerateSelfSignedCertificateWithCA("kafka-tls-basic-auth")
-	if err != nil {
-		panic(fmt.Errorf("failed to generate self signed certificate: %w", err))
-	}
+	// Format the storage with the SCRAM credentials, then start the broker.
+	startScript := "set -e\n" +
+		"CID=$(/opt/kafka/bin/kafka-storage.sh random-uuid)\n" +
+		"/opt/kafka/bin/kafka-storage.sh format -t \"$CID\" -c /etc/kafka/secrets/server.properties " +
+		"--add-scram SCRAM-SHA-512=[name=user,password=password] --ignore-formatted\n" +
+		"exec /opt/kafka/bin/kafka-server-start.sh /etc/kafka/secrets/server.properties\n"
 
-	tlsDir := dag.Directory().
-		WithNewFile("kafka.keystore.key", string(key)).
-		WithNewFile("kafka.keystore.pem", string(cert)).
-		WithNewFile("kafka.truststore.pem", string(cacert))
+	tlsDir := kafkaTLSDirectory("kafka-tls-basic-auth").
+		WithNewFile("server.properties", kafkaSASLProperties)
 
 	return dag.Container().
-		//	Set container image
 		From(kafkaImage).
-
-		// Add environment variables
-		WithEnvVariable("KAFKA_CFG_NODE_ID", "0").
-		WithEnvVariable("KAFKA_CFG_PROCESS_ROLES", "controller,broker").
-		WithEnvVariable("KAFKA_CFG_LISTENERS", "INTERNAL://:9092,CONTROLLER://:9093").
-		WithEnvVariable("KAFKA_CFG_ADVERTISED_LISTENERS", "INTERNAL://kafka-tls-basic-auth:9092").
-		WithEnvVariable("KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP",
-			"CONTROLLER:PLAINTEXT,INTERNAL:SASL_SSL").
-		WithEnvVariable("KAFKA_CFG_CONTROLLER_QUORUM_VOTERS", "0@:9093").
-		WithEnvVariable("KAFKA_CFG_CONTROLLER_LISTENER_NAMES", "CONTROLLER").
-		WithEnvVariable("KAFKA_CFG_INTER_BROKER_LISTENER_NAME", "INTERNAL").
-		WithEnvVariable("KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL", "SCRAM-SHA-512").
-
-		// Add tls config
-		WithEnvVariable("KAFKA_TLS_TYPE", "PEM").
-
-		// add basic auth user and pw
-		// WithEnvVariable("KAFKA_CLIENT_USERS", "user").
-		// WithEnvVariable("KAFKA_CLIENT_PASSWORDS", "password").
-		WithEnvVariable("KAFKA_INTER_BROKER_USER", "user").
-		WithEnvVariable("KAFKA_INTER_BROKER_PASSWORD", "password").
-		// disable client cert
-		WithEnvVariable("KAFKA_TLS_CLIENT_AUTH", "none").
-
-		// Add exposed ports
+		WithDirectory("/etc/kafka/secrets", tlsDir).
 		WithExposedPort(9092).
 		WithExposedPort(9093).
-
-		// Add server cert and key directory
-		WithDirectory("/bitnami/kafka/config/certs/", tlsDir)
+		WithoutEntrypoint().
+		WithExec([]string{"bash", "-c", startScript})
 }
 
 // brokerNATS returns a container for the NATS broker.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,8 +77,13 @@ services:
       - ./tmp/certs/nats:/certs
 
   # Kafka variants
+  #
+  # The official Apache Kafka image (apache/kafka) is used instead of the
+  # deprecated Bitnami one. It maps KAFKA_<PROPERTY> environment variables
+  # straight to server.properties, so the values below are plain Kafka
+  # properties (no KAFKA_CFG_ prefix, no Bitnami-specific TLS helpers).
   kafka:
-    image: bitnamilegacy/kafka:3.5.1
+    image: apache/kafka:3.9.0
     ports:
       - 9092:9092
       - 9093:9093
@@ -86,16 +91,22 @@ services:
       - 9092
       - 9093
     environment:
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_LISTENERS=INTERNAL://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=INTERNAL://localhost:9092
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@:9093
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_NODE_ID=0
+      - KAFKA_PROCESS_ROLES=controller,broker
+      - KAFKA_LISTENERS=INTERNAL://:9092,CONTROLLER://:9093
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://localhost:9092
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=0@localhost:9093
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      # Single-broker replication factors so the internal topics (consumer
+      # offsets, transaction state) can be created on this one-node cluster.
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
   kafka-tls:
-    image: bitnamilegacy/kafka:3.5.1
+    image: apache/kafka:3.9.0
     ports:
       - 9094:9094
       - 9095:9095
@@ -103,41 +114,71 @@ services:
       - 9094
       - 9095
     environment:
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_LISTENERS=INTERNAL://:9094,CONTROLLER://:9095
-      - KAFKA_CFG_ADVERTISED_LISTENERS=INTERNAL://localhost:9094
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:SSL
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@:9095
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INTERNAL
-      - KAFKA_TLS_TYPE=PEM
-      - KAFKA_TLS_CLIENT_AUTH=none
+      - KAFKA_NODE_ID=0
+      - KAFKA_PROCESS_ROLES=controller,broker
+      - KAFKA_LISTENERS=INTERNAL://:9094,CONTROLLER://:9095
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://localhost:9094
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:SSL
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=0@localhost:9095
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      # PEM keystore (certificate chain + private key in a single file) and CA
+      # truststore so the broker trusts its own certificate over the SSL
+      # inter-broker listener. Client certificate authentication is disabled.
+      - KAFKA_SSL_KEYSTORE_TYPE=PEM
+      - KAFKA_SSL_KEYSTORE_LOCATION=/etc/kafka/secrets/kafka.keystore.combined.pem
+      - KAFKA_SSL_TRUSTSTORE_TYPE=PEM
+      - KAFKA_SSL_TRUSTSTORE_LOCATION=/etc/kafka/secrets/kafka.truststore.pem
+      - KAFKA_SSL_CLIENT_AUTH=none
+      # Single-broker replication factors (see the plaintext broker above).
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
     volumes:
-      - ./tmp/certs/kafka:/bitnami/kafka/config/certs/
+      - ./tmp/certs/kafka:/etc/kafka/secrets
   kafka-tls-basic-auth:
-    image: bitnamilegacy/kafka:3.5.1
+    image: apache/kafka:3.9.0
     ports:
       - 9096:9096
       - 9097:9097
     expose:
       - 9096
       - 9097
-    environment:
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_LISTENERS=INTERNAL://:9096,CONTROLLER://:9097
-      - KAFKA_CFG_ADVERTISED_LISTENERS=INTERNAL://localhost:9096
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:SASL_SSL
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@:9097
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INTERNAL
-      - KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=SCRAM-SHA-512
-      - KAFKA_TLS_TYPE=PEM
-      - KAFKA_TLS_CLIENT_AUTH=none
-      - KAFKA_INTER_BROKER_USER=user
-      - KAFKA_INTER_BROKER_PASSWORD=password
     volumes:
-      - ./tmp/certs/kafka:/bitnami/kafka/config/certs/
-    
-  
+      - ./tmp/certs/kafka:/etc/kafka/secrets
+    # SASL_SSL with SCRAM-SHA-512 requires the SCRAM credentials to be present in
+    # the KRaft metadata log, which can only be done at format time via
+    # `--add-scram`. The official image formats storage itself and offers no hook
+    # for this, so the storage is formatted explicitly before the broker starts.
+    entrypoint: ["bash", "-c"]
+    command:
+      - |
+        cat > /tmp/server.properties <<'EOF'
+        node.id=0
+        process.roles=controller,broker
+        listeners=INTERNAL://:9096,CONTROLLER://:9097
+        advertised.listeners=INTERNAL://localhost:9096
+        listener.security.protocol.map=CONTROLLER:PLAINTEXT,INTERNAL:SASL_SSL
+        controller.quorum.voters=0@localhost:9097
+        controller.listener.names=CONTROLLER
+        inter.broker.listener.name=INTERNAL
+        log.dirs=/tmp/kraft-combined-logs
+        offsets.topic.replication.factor=1
+        transaction.state.log.replication.factor=1
+        transaction.state.log.min.isr=1
+        group.initial.rebalance.delay.ms=0
+        sasl.enabled.mechanisms=SCRAM-SHA-512
+        sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
+        listener.name.internal.sasl.enabled.mechanisms=SCRAM-SHA-512
+        listener.name.internal.scram-sha-512.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="user" password="password";
+        ssl.keystore.type=PEM
+        ssl.keystore.location=/etc/kafka/secrets/kafka.keystore.combined.pem
+        ssl.truststore.type=PEM
+        ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.pem
+        ssl.client.auth=none
+        EOF
+        CID=$(/opt/kafka/bin/kafka-storage.sh random-uuid)
+        /opt/kafka/bin/kafka-storage.sh format -t "$CID" -c /tmp/server.properties \
+          --add-scram SCRAM-SHA-512=[name=user,password=password] --ignore-formatted
+        exec /opt/kafka/bin/kafka-server-start.sh /tmp/server.properties

--- a/tools/generate-certs/main.go
+++ b/tools/generate-certs/main.go
@@ -50,9 +50,14 @@ func createKafkaCerts() {
 	keyPath := filepath.Join(basePath, "kafka.keystore.key")
 	certPath := filepath.Join(basePath, "kafka.keystore.pem")
 	caPath := filepath.Join(basePath, "kafka.truststore.pem")
+	// combinedPath holds the certificate chain and the private key in a single
+	// PEM file, which is the format expected by Kafka's `ssl.keystore.location`
+	// when `ssl.keystore.type=PEM` (the Apache Kafka image, unlike Bitnami, does
+	// not assemble the keystore from separate files).
+	combinedPath := filepath.Join(basePath, "kafka.keystore.combined.pem")
 
 	// Check if one file is missing
-	if !checkIfOneOfFilesIsMissing(keyPath, certPath, caPath) {
+	if !checkIfOneOfFilesIsMissing(keyPath, certPath, caPath, combinedPath) {
 		return
 	}
 
@@ -77,6 +82,12 @@ func createKafkaCerts() {
 	}
 
 	if err := os.WriteFile(caPath, cacert, os.ModePerm); err != nil {
+		panic(err)
+	}
+
+	// Export the combined keystore (certificate chain followed by the private key).
+	combined := append(append([]byte{}, cert...), key...)
+	if err := os.WriteFile(combinedPath, combined, os.ModePerm); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Summary

The Bitnami Docker Hub catalog was deprecated in 2025. The previous fix (#304) repointed Kafka to `bitnamilegacy/kafka:3.5.1` to unblock CI, but that org is a frozen archive. This migrates the test/CI Kafka brokers to the **official Apache Kafka image** (`apache/kafka:3.9.0`) — the durable path off the legacy org.

The Apache image maps `KAFKA_<PROPERTY>` env vars straight to `server.properties` and has none of Bitnami's TLS/SASL conveniences, so the three broker variants were reworked:

- **plaintext** — env-var config, plus single-node replication factors.
- **`kafka-tls`** — PEM `ssl.keystore`/`ssl.truststore` (replacing `KAFKA_TLS_TYPE=PEM`). The keystore must be a single file holding the certificate chain **and** private key, so the cert generator now also emits `kafka.keystore.combined.pem`.
- **`kafka-tls-basic-auth`** (SASL_SSL + SCRAM-SHA-512) — SCRAM credentials in KRaft mode must live in the metadata log and can only be added at format time. The official image offers no hook for this, so the broker formats storage explicitly with `--add-scram` before starting.

Also sets `offsets.topic`/`transaction.state.log` replication factors to `1` so the internal topics (and therefore **consumer groups**) work on a one-node cluster — Bitnami defaulted these, the Apache image does not.

## Validation

Run locally against `docker compose` (mirrors `make test`):

- `go test ./...` — **all pass**, including the SCRAM-over-TLS pub/sub integration suite (`test/v2/issues/169`) and the Kafka secure-connection tests.
- Confirmed the original failure mode (consumer groups hanging because `__consumer_offsets` couldn't be created with default RF=3 on a single broker) is resolved.

The Dagger CI broker definitions are migrated to mirror the compose setup; the Dagger path is exercised by this PR's CI run.

## Files
- `docker-compose.yaml` — 3 Kafka services reworked for the Apache image.
- `build/ci/dagger/brokers.go` — same migration for the Dagger CI brokers.
- `tools/generate-certs/main.go` — emit the combined PEM keystore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)