### PR TITLE
refactor: deduplicate v2/v3 template helpers into shared generics

### DIFF
--- a/pkg/asyncapi/v2/schema.go
+++ b/pkg/asyncapi/v2/schema.go
@@ -305,6 +305,24 @@ func (s Schema) IsFieldRequired(field string) bool {
 	return utils.IsInSlice(s.Required, field)
 }
 
+// The accessors below let this Schema satisfy the generators.TemplateSchema
+// generic interface, which backs the template helpers shared between v2 and v3.
+
+// GetType returns the schema type.
+func (s Schema) GetType() string { return s.Type }
+
+// GetIsRequired returns whether the schema itself is required.
+func (s Schema) GetIsRequired() bool { return s.IsRequired }
+
+// GetProperties returns the schema properties.
+func (s Schema) GetProperties() map[string]*Schema { return s.Properties }
+
+// GetItems returns the schema items.
+func (s Schema) GetItems() *Schema { return s.Items }
+
+// GetAdditionalProperties returns the schema additional properties.
+func (s Schema) GetAdditionalProperties() *Schema { return s.AdditionalProperties }
+
 func (s *Schema) referenceFrom(ref []string) *Schema {
 	if len(ref) == 0 {
 		return s

--- a/pkg/asyncapi/v3/schema.go
+++ b/pkg/asyncapi/v3/schema.go
@@ -308,6 +308,24 @@ func (s Schema) IsFieldRequired(field string) bool {
 	return utils.IsInSlice(s.Required, field)
 }
 
+// The accessors below let this Schema satisfy the generators.TemplateSchema
+// generic interface, which backs the template helpers shared between v2 and v3.
+
+// GetType returns the schema type.
+func (s Schema) GetType() string { return s.Type }
+
+// GetIsRequired returns whether the schema itself is required.
+func (s Schema) GetIsRequired() bool { return s.IsRequired }
+
+// GetProperties returns the schema properties.
+func (s Schema) GetProperties() map[string]*Schema { return s.Properties }
+
+// GetItems returns the schema items.
+func (s Schema) GetItems() *Schema { return s.Items }
+
+// GetAdditionalProperties returns the schema additional properties.
+func (s Schema) GetAdditionalProperties() *Schema { return s.AdditionalProperties }
+
 func (s *Schema) referenceFrom(ref []string) *Schema {
 	if len(ref) == 0 {
 		return s

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -9,10 +9,9 @@ import (
 	"github.com/lerenn/asyncapi-codegen/pkg/asyncapi/parser"
 	asyncapiv2 "github.com/lerenn/asyncapi-codegen/pkg/asyncapi/v2"
 	asyncapiv3 "github.com/lerenn/asyncapi-codegen/pkg/asyncapi/v3"
+	"github.com/lerenn/asyncapi-codegen/pkg/codegen/generators"
 	generatorv2 "github.com/lerenn/asyncapi-codegen/pkg/codegen/generators/v2"
-	templatesv2 "github.com/lerenn/asyncapi-codegen/pkg/codegen/generators/v2/templates"
 	generatorv3 "github.com/lerenn/asyncapi-codegen/pkg/codegen/generators/v3"
-	templatesv3 "github.com/lerenn/asyncapi-codegen/pkg/codegen/generators/v3/templates"
 	"github.com/lerenn/asyncapi-codegen/pkg/codegen/options"
 	"github.com/lerenn/asyncapi-codegen/pkg/utils/template"
 	"golang.org/x/tools/imports"
@@ -93,8 +92,7 @@ func (cg CodeGen) Generate(opt options.Options) error {
 	if opt.IgnoreStringFormat {
 		template.DisableDateOrTimeGeneration()
 	}
-	templatesv2.SetForcePointers(opt.ForcePointers)
-	templatesv3.SetForcePointers(opt.ForcePointers)
+	generators.SetForcePointers(opt.ForcePointers)
 
 	// Process Specification
 	if err := cg.Specification.Process(); err != nil {

--- a/pkg/codegen/generators/template_helpers.go
+++ b/pkg/codegen/generators/template_helpers.go
@@ -1,0 +1,116 @@
+package generators
+
+import (
+	"strings"
+
+	"github.com/lerenn/asyncapi-codegen/pkg/utils"
+	"github.com/lerenn/asyncapi-codegen/pkg/utils/template"
+)
+
+// These mirror the asyncapi v2/v3 SchemaType values. They are duplicated here as
+// plain strings so that this package stays version-agnostic (it must not import
+// the concrete v2/v3 packages, which would create an import cycle with the
+// template packages that depend on it).
+const (
+	schemaTypeObject = "object"
+	schemaTypeArray  = "array"
+)
+
+// messageFieldHeader mirrors the v2/v3 MessageFieldIsHeader value. A reference
+// segment equal to it is rendered as the generated "headers" struct field.
+const messageFieldHeader = "header"
+
+// TemplateSchema is the minimal view of an asyncapi Schema (v2 or v3) needed by
+// the template helpers shared between both versions. The type parameter T is the
+// concrete Schema type, so child schemas keep their concrete type. Both
+// asyncapi/v2.Schema and asyncapi/v3.Schema implement TemplateSchema of themselves.
+type TemplateSchema[T any] interface {
+	GetType() string
+	GetIsRequired() bool
+	IsFieldRequired(field string) bool
+	GetProperties() map[string]*T
+	GetItems() *T
+	GetAdditionalProperties() *T
+}
+
+// GetChildrenObjectSchemas returns all the children object schemas of a schema,
+// only from the first level and without AnyOf, AllOf and OneOf.
+func GetChildrenObjectSchemas[T TemplateSchema[T]](s T) []*T {
+	allSchemas := utils.MapToList(s.GetProperties())
+
+	if items := s.GetItems(); items != nil {
+		allSchemas = append(allSchemas, items)
+	}
+
+	if additional := s.GetAdditionalProperties(); additional != nil {
+		allSchemas = append(allSchemas, additional)
+	}
+
+	// Only keep object schemas (and arrays of objects).
+	filteredSchemas := make([]*T, 0, len(allSchemas))
+	for _, child := range allSchemas {
+		schema := *child // concrete T exposes the TemplateSchema methods
+		switch {
+		case schema.GetType() == schemaTypeObject:
+			filteredSchemas = append(filteredSchemas, child)
+		case schema.GetType() == schemaTypeArray:
+			if items := schema.GetItems(); items != nil && (*items).GetType() == schemaTypeObject {
+				filteredSchemas = append(filteredSchemas, items)
+			}
+		}
+	}
+
+	return filteredSchemas
+}
+
+// referenceToSlicePath converts a reference to a slice where each element is a
+// step of the path.
+func referenceToSlicePath(ref string) []string {
+	ref = strings.ReplaceAll(ref, ".", "/")
+	ref = strings.ReplaceAll(ref, "#", "")
+	return strings.Split(ref, "/")[1:]
+}
+
+// ReferenceToStructAttributePath converts a reference to a struct attribute path
+// in the form of "a.b.c" where a, b and c are struct attributes in the form of
+// golang conventional type names.
+func ReferenceToStructAttributePath(ref string) string {
+	path := referenceToSlicePath(ref)
+
+	for k, v := range path {
+		// If this is concerning the header, then it will be named "headers"
+		if v == messageFieldHeader {
+			v = "headers"
+		}
+
+		path[k] = template.Namify(v)
+	}
+
+	return strings.Join(path, ".")
+}
+
+// IsRequired checks if a field is required in an asyncapi schema.
+func IsRequired[T TemplateSchema[T]](schema T, field string) bool {
+	return schema.IsFieldRequired(field)
+}
+
+// forcePointers, when true, makes every non-array struct field be generated as a
+// pointer. It is set explicitly on every generation run (see SetForcePointers),
+// so the setting does not leak between successive generations sharing the same
+// process.
+var forcePointers bool
+
+// SetForcePointers configures whether all struct fields (except arrays) should be
+// generated as pointers.
+func SetForcePointers(force bool) {
+	forcePointers = force
+}
+
+// IsFieldPointer reports whether a struct field should be generated as a pointer.
+func IsFieldPointer[T TemplateSchema[T]](parent T, field string, schema T) bool {
+	if forcePointers {
+		return schema.GetType() != schemaTypeArray
+	}
+
+	return !(IsRequired(parent, field) || schema.GetIsRequired()) && schema.GetType() != schemaTypeArray
+}

--- a/pkg/codegen/generators/v2/templates/helpers.go
+++ b/pkg/codegen/generators/v2/templates/helpers.go
@@ -8,63 +8,8 @@ import (
 
 	asyncapi "github.com/lerenn/asyncapi-codegen/pkg/asyncapi/v2"
 	"github.com/lerenn/asyncapi-codegen/pkg/codegen/generators"
-	"github.com/lerenn/asyncapi-codegen/pkg/utils"
 	templateutil "github.com/lerenn/asyncapi-codegen/pkg/utils/template"
 )
-
-// GetChildrenObjectSchemas will return all the children object schemas of a
-// schema, only from first level and without AnyOf, AllOf and OneOf.
-func GetChildrenObjectSchemas(s asyncapi.Schema) []*asyncapi.Schema {
-	allSchemas := utils.MapToList(s.Properties)
-
-	if s.Items != nil {
-		allSchemas = append(allSchemas, s.Items)
-	}
-
-	if s.AdditionalProperties != nil {
-		allSchemas = append(allSchemas, s.AdditionalProperties)
-	}
-
-	// Only keep object schemas
-	filteredSchemas := make([]*asyncapi.Schema, 0, len(allSchemas))
-	for _, schema := range allSchemas {
-		if schema.Type == asyncapi.SchemaTypeIsObject.String() {
-			filteredSchemas = append(filteredSchemas, schema)
-		} else if schema.Type == asyncapi.SchemaTypeIsArray.String() &&
-			schema.Items != nil &&
-			schema.Items.Type == asyncapi.SchemaTypeIsObject.String() {
-			filteredSchemas = append(filteredSchemas, schema.Items)
-		}
-	}
-
-	return filteredSchemas
-}
-
-// referenceToSlicePath will convert a reference to a slice where each element is a
-// step of the path.
-func referenceToSlicePath(ref string) []string {
-	ref = strings.ReplaceAll(ref, ".", "/")
-	ref = strings.ReplaceAll(ref, "#", "")
-	return strings.Split(ref, "/")[1:]
-}
-
-// ReferenceToStructAttributePath will convert a reference to a struct attribute
-// path in the form of "a.b.c" where a, b and c are struct attributes in the
-// form of golang conventional type names.
-func ReferenceToStructAttributePath(ref string) string {
-	path := referenceToSlicePath(ref)
-
-	for k, v := range path {
-		// If this is concerning the header, then it will be named "headers"
-		if v == asyncapi.MessageFieldIsHeader.String() {
-			v = "headers"
-		}
-
-		path[k] = templateutil.Namify(v)
-	}
-
-	return strings.Join(path, ".")
-}
 
 // ReferenceToTypeName will convert a reference to a type name in the form of
 // golang conventional type names.
@@ -100,11 +45,6 @@ func ChannelToMessage(ch asyncapi.Channel, direction string) (*asyncapi.Message,
 	default:
 		return nil, fmt.Errorf("direction must be either 'publish' or 'subscribe', got %q", direction)
 	}
-}
-
-// IsRequired will check if a field is required in a asyncapi struct.
-func IsRequired(schema asyncapi.Schema, field string) bool {
-	return schema.IsFieldRequired(field)
 }
 
 // GenerateChannelPath will generate a channel path with the given channel.
@@ -147,35 +87,16 @@ func OperationName(channel asyncapi.Channel) string {
 	return templateutil.Namify(name)
 }
 
-func defaultIsFieldPointer(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
-	return !(IsRequired(parent, field) || schema.IsRequired) && schema.Type != "array"
-}
-
-var isFieldPointer = defaultIsFieldPointer
-
-// SetForcePointers configures whether all struct fields (except arrays) should be
-// generated as pointers. It is reset on every generation run so the setting does
-// not leak between successive generations sharing the same process.
-func SetForcePointers(force bool) {
-	if force {
-		isFieldPointer = func(_ asyncapi.Schema, _ string, schema asyncapi.Schema) bool {
-			return schema.Type != "array"
-		}
-		return
-	}
-	isFieldPointer = defaultIsFieldPointer
-}
-
 // HelpersFunctions returns the functions that can be used as helpers
 // in a golang template.
 func HelpersFunctions() template.FuncMap {
 	return template.FuncMap{
-		"getChildrenObjectSchemas":       GetChildrenObjectSchemas,
+		"getChildrenObjectSchemas":       generators.GetChildrenObjectSchemas[asyncapi.Schema],
 		"channelToMessage":               ChannelToMessage,
-		"isRequired":                     IsRequired,
-		"isFieldPointer":                 isFieldPointer,
+		"isRequired":                     generators.IsRequired[asyncapi.Schema],
+		"isFieldPointer":                 generators.IsFieldPointer[asyncapi.Schema],
 		"generateChannelPath":            GenerateChannelPath,
-		"referenceToStructAttributePath": ReferenceToStructAttributePath,
+		"referenceToStructAttributePath": generators.ReferenceToStructAttributePath,
 		"operationName":                  OperationName,
 		"referenceToTypeName":            ReferenceToTypeName,
 		"generateValidateTags":           generators.GenerateValidateTags[asyncapi.Schema],

--- a/pkg/codegen/generators/v2/templates/helpers_test.go
+++ b/pkg/codegen/generators/v2/templates/helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lerenn/asyncapi-codegen/pkg/asyncapi"
 	asyncapiv2 "github.com/lerenn/asyncapi-codegen/pkg/asyncapi/v2"
+	"github.com/lerenn/asyncapi-codegen/pkg/codegen/generators"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -45,7 +46,7 @@ func (suite *HelpersSuite) TestIsRequired() {
 	}
 
 	for i, c := range cases {
-		suite.Require().Equal(c.Result, IsRequired(c.Schema, c.Field), i)
+		suite.Require().Equal(c.Result, generators.IsRequired(c.Schema, c.Field), i)
 	}
 }
 

--- a/pkg/codegen/generators/v3/templates/helpers.go
+++ b/pkg/codegen/generators/v3/templates/helpers.go
@@ -3,68 +3,12 @@ package templates
 import (
 	"fmt"
 	"regexp"
-	"strings"
 	"text/template"
 
 	asyncapi "github.com/lerenn/asyncapi-codegen/pkg/asyncapi/v3"
 	"github.com/lerenn/asyncapi-codegen/pkg/codegen/generators"
-	"github.com/lerenn/asyncapi-codegen/pkg/utils"
 	templateutil "github.com/lerenn/asyncapi-codegen/pkg/utils/template"
 )
-
-// GetChildrenObjectSchemas will return all the children object schemas of a
-// schema, only from first level and without AnyOf, AllOf and OneOf.
-func GetChildrenObjectSchemas(s asyncapi.Schema) []*asyncapi.Schema {
-	allSchemas := utils.MapToList(s.Properties)
-
-	if s.Items != nil {
-		allSchemas = append(allSchemas, s.Items)
-	}
-
-	if s.AdditionalProperties != nil {
-		allSchemas = append(allSchemas, s.AdditionalProperties)
-	}
-
-	// Only keep object schemas
-	filteredSchemas := make([]*asyncapi.Schema, 0, len(allSchemas))
-	for _, schema := range allSchemas {
-		if schema.Type == asyncapi.SchemaTypeIsObject.String() {
-			filteredSchemas = append(filteredSchemas, schema)
-		} else if schema.Type == asyncapi.SchemaTypeIsArray.String() &&
-			schema.Items != nil &&
-			schema.Items.Type == asyncapi.SchemaTypeIsObject.String() {
-			filteredSchemas = append(filteredSchemas, schema.Items)
-		}
-	}
-
-	return filteredSchemas
-}
-
-// referenceToSlicePath will convert a reference to a slice where each element is a
-// step of the path.
-func referenceToSlicePath(ref string) []string {
-	ref = strings.ReplaceAll(ref, ".", "/")
-	ref = strings.ReplaceAll(ref, "#", "")
-	return strings.Split(ref, "/")[1:]
-}
-
-// ReferenceToStructAttributePath will convert a reference to a struct attribute
-// path in the form of "a.b.c" where a, b and c are struct attributes in the
-// form of golang conventional type names.
-func ReferenceToStructAttributePath(ref string) string {
-	path := referenceToSlicePath(ref)
-
-	for k, v := range path {
-		// If this is concerning the header, then it will be named "headers"
-		if v == asyncapi.MessageFieldIsHeader.String() {
-			v = "headers"
-		}
-
-		path[k] = templateutil.Namify(v)
-	}
-
-	return strings.Join(path, ".")
-}
 
 // ChannelToMessageTypeName will convert a channel to a message type name in the
 // form of golang conventional type names.
@@ -91,11 +35,6 @@ func OpToMsgTypeName(op asyncapi.Operation) (string, error) {
 func OpToChannelTypeName(op asyncapi.Operation) string {
 	ch := op.Channel.Follow()
 	return templateutil.Namify(ch.Name)
-}
-
-// IsRequired will check if a field is required in a asyncapi struct.
-func IsRequired(schema asyncapi.Schema, field string) bool {
-	return schema.IsFieldRequired(field)
 }
 
 // GenerateChannelAddrFromOp will generate a channel path with the given operation.
@@ -130,38 +69,19 @@ func GenerateChannelAddr(ch *asyncapi.Channel) string {
 	return sprint[:len(sprint)-1] + ")"
 }
 
-func defaultIsFieldPointer(parent asyncapi.Schema, field string, schema asyncapi.Schema) bool {
-	return !(IsRequired(parent, field) || schema.IsRequired) && schema.Type != "array"
-}
-
-var isFieldPointer = defaultIsFieldPointer
-
-// SetForcePointers configures whether all struct fields (except arrays) should be
-// generated as pointers. It is reset on every generation run so the setting does
-// not leak between successive generations sharing the same process.
-func SetForcePointers(force bool) {
-	if force {
-		isFieldPointer = func(_ asyncapi.Schema, _ string, schema asyncapi.Schema) bool {
-			return schema.Type != "array"
-		}
-		return
-	}
-	isFieldPointer = defaultIsFieldPointer
-}
-
 // HelpersFunctions returns the functions that can be used as helpers
 // in a golang template.
 func HelpersFunctions() template.FuncMap {
 	return template.FuncMap{
-		"getChildrenObjectSchemas":       GetChildrenObjectSchemas,
+		"getChildrenObjectSchemas":       generators.GetChildrenObjectSchemas[asyncapi.Schema],
 		"channelToMessageTypeName":       ChannelToMessageTypeName,
 		"opToMsgTypeName":                OpToMsgTypeName,
 		"opToChannelTypeName":            OpToChannelTypeName,
-		"isRequired":                     IsRequired,
-		"isFieldPointer":                 isFieldPointer,
+		"isRequired":                     generators.IsRequired[asyncapi.Schema],
+		"isFieldPointer":                 generators.IsFieldPointer[asyncapi.Schema],
 		"generateChannelAddr":            GenerateChannelAddr,
 		"generateChannelAddrFromOp":      GenerateChannelAddrFromOp,
-		"referenceToStructAttributePath": ReferenceToStructAttributePath,
+		"referenceToStructAttributePath": generators.ReferenceToStructAttributePath,
 		"generateValidateTags":           generators.GenerateValidateTags[asyncapi.Schema],
 		"generateJSONTags":               generators.GenerateJSONTags[asyncapi.Schema],
 	}

--- a/pkg/codegen/generators/v3/templates/helpers_test.go
+++ b/pkg/codegen/generators/v3/templates/helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lerenn/asyncapi-codegen/pkg/asyncapi"
 	asyncapiv3 "github.com/lerenn/asyncapi-codegen/pkg/asyncapi/v3"
+	"github.com/lerenn/asyncapi-codegen/pkg/codegen/generators"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -45,7 +46,7 @@ func (suite *HelpersSuite) TestIsRequired() {
 	}
 
 	for i, c := range cases {
-		suite.Require().Equal(c.Result, IsRequired(c.Schema, c.Field), i)
+		suite.Require().Equal(c.Result, generators.IsRequired(c.Schema, c.Field), i)
 	}
 }
 


### PR DESCRIPTION
## What

The v2 and v3 template helper packages (`pkg/codegen/generators/{v2,v3}/templates/helpers.go`) each carried **byte-identical** copies of several helpers. This PR extracts them into the existing shared `pkg/codegen/generators` package as generic functions, leaving a single source of truth.

Deduplicated:
- `GetChildrenObjectSchemas`
- `referenceToSlicePath` + `ReferenceToStructAttributePath`
- `IsRequired`
- the `isFieldPointer` / `SetForcePointers` (force-pointers) machinery

## How

The shared functions are generic over a new `TemplateSchema[T]` interface:

```go
type TemplateSchema[T any] interface {
    GetType() string
    GetIsRequired() bool
    IsFieldRequired(field string) bool
    GetProperties() map[string]*T
    GetItems() *T
    GetAdditionalProperties() *T
}
```

Both `asyncapi/v2.Schema` and `asyncapi/v3.Schema` satisfy it via a small set of plain accessor methods (`GetType`, `GetIsRequired`, `GetProperties`, `GetItems`, `GetAdditionalProperties`) added to each. Interface satisfaction is structural, so the `asyncapi/v{2,3}` packages gain **no** dependency on `generators` — no import cycle.

The force-pointers state is consolidated into the shared package too, so `codegen.go` now makes a single `generators.SetForcePointers(...)` call instead of one per version.

The version-specific helpers (channel/operation/message name generation, etc.) are untouched and stay in their respective packages.

## Verification

- `go build ./...` — clean
- `golangci-lint run` — clean
- `go test ./pkg/codegen/... ./pkg/asyncapi/...` — pass
- **`go generate ./...` produces zero diff** — the generated code is byte-identical, proving the refactor is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)