### PR TITLE
doc(CONTRIBUTORS): add Matthias Nösner as a contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@ adventure, this file is a attempt to show them the respect they earned.
 * [André (@andiikaa)](https://github.com/andiikaa)
 * [Justen Stall (@justenstall)](https://github.com/justenstall)
 * [Lucas Mendes (@lmendes86)](https://github.com/lmendes86)
+* [Matthias Nösner (@Equanox)](https://github.com/Equanox)
 * And maybe you ?
 
 ## I would like to join the list. How can I help the project?


### PR DESCRIPTION
Adds [Matthias Nösner (@Equanox)](https://github.com/Equanox) to the contributors list for adding configurable kafka writer options in #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)