### PR TITLE
fix(kafka): keep consuming after a transient read error

### DIFF
--- a/pkg/extensions/brokers/kafka/consumer_test.go
+++ b/pkg/extensions/brokers/kafka/consumer_test.go
@@ -1,0 +1,112 @@
+package kafka
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/lerenn/asyncapi-codegen/pkg/extensions"
+	kafkago "github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedReader returns a predefined sequence of (message, error) results and
+// then io.EOF, letting us drive the consumption loop without a live broker.
+type scriptedReader struct {
+	steps []scriptedStep
+	index int
+}
+
+type scriptedStep struct {
+	msg kafkago.Message
+	err error
+}
+
+func (r *scriptedReader) next() (kafkago.Message, error) {
+	if r.index >= len(r.steps) {
+		return kafkago.Message{}, io.EOF
+	}
+	step := r.steps[r.index]
+	r.index++
+
+	return step.msg, step.err
+}
+
+func (r *scriptedReader) ReadMessage(_ context.Context) (kafkago.Message, error)  { return r.next() }
+func (r *scriptedReader) FetchMessage(_ context.Context) (kafkago.Message, error) { return r.next() }
+func (r *scriptedReader) CommitMessages(_ context.Context, _ ...kafkago.Message) error {
+	return nil
+}
+
+// TestConsumerContinuesAfterTransientError ensures that a transient read error
+// does not kill the subscription: the handler must keep consuming and still
+// deliver the next message (issue #285). Before the fix, any non-EOF error made
+// the handler return, so the message after the error was never delivered.
+func TestConsumerContinuesAfterTransientError(t *testing.T) {
+	logger := extensions.Logger(extensions.DummyLogger{})
+
+	reader := &scriptedReader{steps: []scriptedStep{
+		{err: errors.New("transient: connection reset by peer")},
+		{msg: kafkago.Message{Value: []byte("hello")}},
+		// Exhausted afterwards -> io.EOF -> handler returns.
+	}}
+
+	sub := extensions.NewBrokerChannelSubscription(
+		make(chan extensions.AcknowledgeableBrokerMessage, 8),
+		make(chan any, 1),
+	)
+
+	done := make(chan struct{})
+	go func() {
+		autoCommitMessagesHandler(&logger)(context.Background(), reader, sub)
+		close(done)
+	}()
+
+	// The message published after the transient error must still arrive.
+	select {
+	case msg := <-sub.MessagesChannel():
+		require.Equal(t, "hello", string(msg.Payload))
+	case <-time.After(2 * time.Second):
+		t.Fatal("message after transient error was not delivered (handler exited early)")
+	}
+
+	// After exhausting the script, the reader returns io.EOF and the handler stops.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not stop on io.EOF")
+	}
+}
+
+// TestConsumerStopsOnContextCancellation ensures the handler exits when the
+// context is cancelled instead of busy-looping on the resulting error.
+func TestConsumerStopsOnContextCancellation(t *testing.T) {
+	logger := extensions.Logger(extensions.DummyLogger{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A reader that always returns the context error once cancelled.
+	reader := &scriptedReader{steps: []scriptedStep{
+		{err: context.Canceled},
+	}}
+
+	sub := extensions.NewBrokerChannelSubscription(
+		make(chan extensions.AcknowledgeableBrokerMessage, 1),
+		make(chan any, 1),
+	)
+
+	done := make(chan struct{})
+	go func() {
+		autoCommitMessagesHandler(&logger)(ctx, reader, sub)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not stop after context cancellation")
+	}
+}

--- a/pkg/extensions/brokers/kafka/kafka.go
+++ b/pkg/extensions/brokers/kafka/kafka.go
@@ -39,9 +39,28 @@ type Controller struct {
 // MessagesHandler is a function that can be used to process messages from the broker.
 type MessagesHandler func(
 	ctx context.Context,
-	r *kafka.Reader,
+	r messageReader,
 	sub extensions.BrokerChannelSubscription,
 )
+
+// messageReader abstracts the parts of *kafka.Reader used by the message
+// handlers, so that the consumption loop can be unit-tested without a live
+// broker. *kafka.Reader satisfies this interface.
+type messageReader interface {
+	ReadMessage(ctx context.Context) (kafka.Message, error)
+	FetchMessage(ctx context.Context) (kafka.Message, error)
+	CommitMessages(ctx context.Context, msgs ...kafka.Message) error
+}
+
+// shouldStopConsuming reports whether a read error is terminal and the message
+// handler should stop consuming. A cancelled context or a closed reader (EOF /
+// closed pipe) is terminal; any other error is transient and consumption should
+// continue rather than silently killing the subscription.
+func shouldStopConsuming(ctx context.Context, err error) bool {
+	return ctx.Err() != nil ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrClosedPipe)
+}
 
 // ControllerOption is a function that can be used to configure a Kafka controller
 // Examples: WithGroupID(), WithPartition(), WithMaxBytes(), WithLogger().
@@ -295,17 +314,20 @@ func (c *Controller) checkTopicExistOrCreateIt(ctx context.Context, topic string
 // Maybe consider to use the manualCommitMessagesHandler.
 func autoCommitMessagesHandler(
 	logger *extensions.Logger,
-) func(ctx context.Context, r *kafka.Reader, sub extensions.BrokerChannelSubscription) {
-	return func(ctx context.Context, r *kafka.Reader, sub extensions.BrokerChannelSubscription) {
+) func(ctx context.Context, r messageReader, sub extensions.BrokerChannelSubscription) {
+	return func(ctx context.Context, r messageReader, sub extensions.BrokerChannelSubscription) {
 		for {
 			msg, err := r.ReadMessage(ctx)
 			if err != nil {
-				// If the error is not io.EOF, then it is a real error
-				if !errors.Is(err, io.EOF) {
-					(*logger).Warning(ctx, fmt.Sprintf("Error when reading message: %q", err.Error()))
+				// Stop only on terminal errors (context done or closed reader).
+				// Transient errors should not kill the subscription.
+				if shouldStopConsuming(ctx, err) {
+					return
 				}
 
-				return
+				(*logger).Warning(ctx, fmt.Sprintf("Error when reading message, continuing: %q", err.Error()))
+
+				continue
 			}
 
 			// Get headers
@@ -329,17 +351,20 @@ func autoCommitMessagesHandler(
 // the message is committed by user via the AcknowledgementHandler.
 func manualCommitMessagesHandler(
 	logger *extensions.Logger,
-) func(ctx context.Context, r *kafka.Reader, sub extensions.BrokerChannelSubscription) {
-	return func(ctx context.Context, r *kafka.Reader, sub extensions.BrokerChannelSubscription) {
+) func(ctx context.Context, r messageReader, sub extensions.BrokerChannelSubscription) {
+	return func(ctx context.Context, r messageReader, sub extensions.BrokerChannelSubscription) {
 		for {
 			msg, err := r.FetchMessage(ctx)
 			if err != nil {
-				// If the error is not io.EOF, then it is a real error
-				if !errors.Is(err, io.EOF) {
-					(*logger).Warning(ctx, fmt.Sprintf("Error when reading message: %q", err.Error()))
+				// Stop only on terminal errors (context done or closed reader).
+				// Transient errors should not kill the subscription.
+				if shouldStopConsuming(ctx, err) {
+					return
 				}
 
-				return
+				(*logger).Warning(ctx, fmt.Sprintf("Error when reading message, continuing: %q", err.Error()))
+
+				continue
 			}
 
 			// Get headers


### PR DESCRIPTION
## Description

Fixes #285.

Both `autoCommitMessagesHandler` and `manualCommitMessagesHandler` returned on **any** non-EOF error from `ReadMessage`/`FetchMessage`:

```go
if err != nil {
    if !errors.Is(err, io.EOF) {
        (*logger).Warning(ctx, ...)
    }
    return // <-- kills the subscription goroutine on any error
}
```

A single transient error therefore terminated the consumer goroutine permanently. The subscription channel stayed open, so the consumer looked alive but was silently dead, with only a logged warning.

### Fix

Classify the error before deciding to stop:

- **Terminal** — a cancelled context (`ctx.Err() != nil`) or a closed reader (`io.EOF` / `io.ErrClosedPipe`): return (clean shutdown). A blanket `continue` would busy-loop here.
- **Transient** — any other error: log it and `continue` consuming instead of killing the subscription.

To make the loop unit-testable without a live broker, the handlers now take a small `messageReader` interface (`ReadMessage`/`FetchMessage`/`CommitMessages`) that `*kafka.Reader` already satisfies.

### Tests

Added `pkg/extensions/brokers/kafka/consumer_test.go` with a scripted in-memory reader:
- `TestConsumerContinuesAfterTransientError` — a transient error followed by a message; the message must still be delivered. Fails before the fix (handler exits early, message never delivered), passes after.
- `TestConsumerStopsOnContextCancellation` — the handler exits promptly when the context is cancelled (no busy-loop).

No Kafka container required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)