### PR TITLE
feat: add an opt-in payload validation middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,6 +849,24 @@ The following tags are currently supported:
 | uniqueItems      | unique         | Only for arrays                                              |
 | enum             | oneof          | Only string enum are supported                               |    
 
+You can validate manually wherever you hold a generated payload, or plug in the
+provided opt-in middleware to reject invalid messages automatically:
+
+```go
+import (
+    "github.com/go-playground/validator/v10"
+    "github.com/lerenn/asyncapi-codegen/pkg/extensions/middlewares"
+)
+
+ctrl, _ := NewUserController(broker, WithMiddlewares(
+    middlewares.Validation(validator.New(), func() any { return &UserMessagePayload{} }),
+))
+```
+
+The middleware unmarshals the message payload and validates it against the
+generated tags; if validation fails it returns an error, so the message is
+neither delivered (on reception) nor sent (on publication).
+
 
 ## Contributing and support
 

--- a/pkg/extensions/middlewares/validation.go
+++ b/pkg/extensions/middlewares/validation.go
@@ -1,0 +1,41 @@
+package middlewares
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/lerenn/asyncapi-codegen/pkg/extensions"
+)
+
+// Validation returns a middleware that validates the message payload against
+// the `validate:"..."` struct tags that asyncapi-codegen generates on payload
+// types (using github.com/go-playground/validator).
+//
+// newPayload must return a pointer to a fresh payload value to decode the
+// message into, for example:
+//
+//	middlewares.Validation(validator.New(), func() any { return &UserMessagePayload{} })
+//
+// The middleware unmarshals msg.Payload (JSON) into that value and validates
+// it. If the payload cannot be unmarshaled or fails validation, it returns an
+// error, which aborts processing of the message — so invalid messages never
+// reach user code (on reception) and are not sent (on publication).
+//
+// A fresh value is created for every message, so the middleware is safe for
+// concurrent use.
+func Validation(validate *validator.Validate, newPayload func() any) extensions.Middleware {
+	return func(ctx context.Context, msg *extensions.BrokerMessage, next extensions.NextMiddleware) error {
+		payload := newPayload()
+
+		if err := json.Unmarshal(msg.Payload, payload); err != nil {
+			return err
+		}
+
+		if err := validate.Struct(payload); err != nil {
+			return err
+		}
+
+		return next(ctx)
+	}
+}

--- a/pkg/extensions/middlewares/validation_test.go
+++ b/pkg/extensions/middlewares/validation_test.go
@@ -1,0 +1,48 @@
+package middlewares_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/lerenn/asyncapi-codegen/pkg/extensions"
+	"github.com/lerenn/asyncapi-codegen/pkg/extensions/middlewares"
+	"github.com/stretchr/testify/require"
+)
+
+type validationPayload struct {
+	Name string `json:"name" validate:"required"`
+}
+
+func TestValidationAllowsValidPayload(t *testing.T) {
+	mw := middlewares.Validation(validator.New(), func() any { return &validationPayload{} })
+
+	called := false
+	next := func(_ context.Context) error {
+		called = true
+		return nil
+	}
+
+	msg := &extensions.BrokerMessage{Payload: []byte(`{"name":"alice"}`)}
+	err := mw(context.Background(), msg, next)
+
+	require.NoError(t, err)
+	require.True(t, called, "next middleware must be called for a valid payload")
+}
+
+func TestValidationRejectsInvalidPayload(t *testing.T) {
+	mw := middlewares.Validation(validator.New(), func() any { return &validationPayload{} })
+
+	called := false
+	next := func(_ context.Context) error {
+		called = true
+		return nil
+	}
+
+	// Missing the required "name" field.
+	msg := &extensions.BrokerMessage{Payload: []byte(`{}`)}
+	err := mw(context.Background(), msg, next)
+
+	require.Error(t, err)
+	require.False(t, called, "next middleware must not be called for an invalid payload")
+}


### PR DESCRIPTION
## Description

Closes #131.

asyncapi-codegen already generates `validate:"..."` struct tags on payload types, but left running the validator entirely to the user. This adds an **opt-in** middleware that enforces them automatically.

```go
import (
    "github.com/go-playground/validator/v10"
    "github.com/lerenn/asyncapi-codegen/pkg/extensions/middlewares"
)

ctrl, _ := NewUserController(broker, WithMiddlewares(
    middlewares.Validation(validator.New(), func() any { return &UserMessagePayload{} }),
))
```

`middlewares.Validation` unmarshals `msg.Payload` into a fresh value from the supplied factory and runs `validate.Struct` on it. On an unmarshal or validation error it returns the error, which aborts the message — so invalid messages never reach user code (reception) and are not sent (publication). A fresh value is created per message, so it is concurrency-safe.

The factory is needed because middlewares operate on the raw `BrokerMessage` and have no type information; the caller supplies the payload type. Manual validation remains available exactly as before.

### Tests

`pkg/extensions/middlewares/validation_test.go`: a valid payload passes through (next is called), an invalid one is rejected (error returned, next not called). Verified the test doesn't compile before the middleware exists and passes after. Documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)