### PR TITLE
feat(loggers): add configurable log level (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,21 @@ func main() {
 
 You can find all loggers in the directory `pkg/log`.
 
+By default, the provided loggers (`NewText` and `NewECS`) output every message.
+You can restrict them to a minimum severity level with the `WithLevel` option:
+
+```golang
+import(
+  log "github.com/lerenn/asyncapi-codegen/pkg/extensions/loggers"
+)
+
+// Only warnings and errors will be printed, info messages are discarded.
+logger := log.NewECS(log.WithLevel(log.LevelWarning))
+```
+
+Available levels are `LevelInfo` (default, logs everything), `LevelWarning`
+(warnings and errors) and `LevelError` (errors only).
+
 #### Publication/Reception logging
 
 To log published and received messages, you'll have to pass a logger as a middleware

--- a/pkg/extensions/loggers/ecs.go
+++ b/pkg/extensions/loggers/ecs.go
@@ -10,11 +10,21 @@ import (
 )
 
 // ECS is a logger that will print logs in Elastic Common Schema ECS format.
-type ECS struct{}
+type ECS struct {
+	level Level
+}
 
 // NewECS creates a new ECS logger.
-func NewECS() ECS {
-	return ECS{}
+func NewECS(options ...Option) ECS {
+	ecs := ECS{}
+	for _, option := range options {
+		option(&ecs)
+	}
+	return ecs
+}
+
+func (ecs *ECS) setLevel(level Level) {
+	ecs.level = level
 }
 
 func (ecs ECS) setInfoFromContext(ctx context.Context, msg string, info ...extensions.LogInfo) []extensions.LogInfo {
@@ -83,11 +93,17 @@ func (ecs ECS) logWithLevel(ctx context.Context, level string, msg string, info 
 
 // Info logs a message at info level with context and additional info.
 func (ecs ECS) Info(ctx context.Context, msg string, info ...extensions.LogInfo) {
+	if ecs.level > LevelInfo {
+		return
+	}
 	ecs.logWithLevel(ctx, "info", msg, info...)
 }
 
 // Warning logs a message at warning level with context and additional info.
 func (ecs ECS) Warning(ctx context.Context, msg string, info ...extensions.LogInfo) {
+	if ecs.level > LevelWarning {
+		return
+	}
 	ecs.logWithLevel(ctx, "warning", msg, info...)
 }
 

--- a/pkg/extensions/loggers/level.go
+++ b/pkg/extensions/loggers/level.go
@@ -1,0 +1,30 @@
+package loggers
+
+// Level is the minimum severity a logger will output. Messages with a severity
+// below the configured level are discarded.
+type Level int
+
+const (
+	// LevelInfo outputs info, warning and error logs. This is the default.
+	LevelInfo Level = iota
+	// LevelWarning outputs warning and error logs only.
+	LevelWarning
+	// LevelError outputs error logs only.
+	LevelError
+)
+
+// levelSetter is implemented by the loggers that support a configurable level.
+type levelSetter interface {
+	setLevel(level Level)
+}
+
+// Option is a functional option shared by the loggers of this package.
+type Option func(levelSetter)
+
+// WithLevel sets the minimum severity level that the logger will output.
+// Messages below this level are silently discarded.
+func WithLevel(level Level) Option {
+	return func(ls levelSetter) {
+		ls.setLevel(level)
+	}
+}

--- a/pkg/extensions/loggers/level_test.go
+++ b/pkg/extensions/loggers/level_test.go
@@ -1,0 +1,93 @@
+package loggers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout runs f and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	f()
+
+	require.NoError(t, w.Close())
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
+func TestECSLevelFiltersLowerSeverity(t *testing.T) {
+	ctx := context.Background()
+
+	// With an error-level logger, info and warning must be discarded but error
+	// must still be printed.
+	logger := NewECS(WithLevel(LevelError))
+
+	assert.Empty(t, captureStdout(t, func() {
+		logger.Info(ctx, "an info message")
+	}), "info should be filtered out at error level")
+
+	assert.Empty(t, captureStdout(t, func() {
+		logger.Warning(ctx, "a warning message")
+	}), "warning should be filtered out at error level")
+
+	out := captureStdout(t, func() {
+		logger.Error(ctx, "an error message")
+	})
+	assert.Contains(t, out, "an error message", "error should always be printed")
+}
+
+func TestECSWarningLevelKeepsWarningAndError(t *testing.T) {
+	ctx := context.Background()
+	logger := NewECS(WithLevel(LevelWarning))
+
+	assert.Empty(t, captureStdout(t, func() {
+		logger.Info(ctx, "an info message")
+	}), "info should be filtered out at warning level")
+
+	assert.Contains(t, captureStdout(t, func() {
+		logger.Warning(ctx, "a warning message")
+	}), "a warning message")
+
+	assert.Contains(t, captureStdout(t, func() {
+		logger.Error(ctx, "an error message")
+	}), "an error message")
+}
+
+func TestECSDefaultLevelLogsEverything(t *testing.T) {
+	ctx := context.Background()
+	logger := NewECS()
+
+	assert.Contains(t, captureStdout(t, func() {
+		logger.Info(ctx, "an info message")
+	}), "an info message", "default logger should print info")
+}
+
+func TestTextLevelFiltersLowerSeverity(t *testing.T) {
+	ctx := context.Background()
+	logger := NewText(WithLevel(LevelError))
+
+	assert.Empty(t, captureStdout(t, func() {
+		logger.Info(ctx, "an info message")
+	}), "info should be filtered out at error level")
+
+	assert.NotEmpty(t, captureStdout(t, func() {
+		logger.Error(ctx, "an error message")
+	}), "error should always be printed")
+}

--- a/pkg/extensions/loggers/text.go
+++ b/pkg/extensions/loggers/text.go
@@ -16,10 +16,15 @@ type Text struct {
 	boldOrangePrinter *color.Color
 	boldWhitePrinter  *color.Color
 	greyPrinter       *color.Color
+	level             Level
+}
+
+func (tl *Text) setLevel(level Level) {
+	tl.level = level
 }
 
 // NewText creates a new Human logger.
-func NewText() Text {
+func NewText(options ...Option) Text {
 	// Create red color
 	red := color.New(color.FgHiRed)
 	boldRed := red.Add(color.Bold)
@@ -32,12 +37,16 @@ func NewText() Text {
 	white := color.New(color.FgWhite)
 	boldWhite := white.Add(color.Bold)
 
-	return Text{
+	tl := Text{
 		boldRedPrinter:    boldRed,
 		boldOrangePrinter: boldOrange,
 		boldWhitePrinter:  boldWhite,
 		greyPrinter:       color.New(color.FgHiBlack),
 	}
+	for _, option := range options {
+		option(&tl)
+	}
+	return tl
 }
 
 func (tl Text) humanizeStructuredLogs(sl map[string]any, msgFmt *color.Color, prefixes ...string) string {
@@ -106,11 +115,17 @@ func (tl Text) formatLog(ctx context.Context, msgFmt *color.Color, msg string, i
 
 // Info logs a message at info level with context and additional info.
 func (tl Text) Info(ctx context.Context, msg string, info ...extensions.LogInfo) {
+	if tl.level > LevelInfo {
+		return
+	}
 	fmt.Println(tl.formatLog(ctx, tl.boldWhitePrinter, msg, info...))
 }
 
 // Warning logs a message at warning level with context and additional info.
 func (tl Text) Warning(ctx context.Context, msg string, info ...extensions.LogInfo) {
+	if tl.level > LevelWarning {
+		return
+	}
 	fmt.Println(tl.formatLog(ctx, tl.boldOrangePrinter, msg, info...))
 }
 


### PR DESCRIPTION
## Issue

Fixes #56 — the provided loggers had no way to set a severity threshold; every message was always emitted.

## Change

Adds a non-breaking `WithLevel(...)` functional option to the `Text` and `ECS` loggers:

- `LevelInfo` (default) — logs info, warning and error (unchanged behavior)
- `LevelWarning` — logs warning and error only
- `LevelError` — logs error only

`NewText()` / `NewECS()` keep working with no arguments. A shared `Option` type lets `WithLevel` apply to either logger.

## Test

`level_test.go` captures stdout and asserts that lower-severity messages are discarded at each level and that the default logs everything. It fails to compile before the change (no `WithLevel`/`Level*`) and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)