### PR TITLE
feat(generators): validate non-string enums and consts (#137)

### DIFF
--- a/pkg/codegen/generators/helpers.go
+++ b/pkg/codegen/generators/helpers.go
@@ -2,6 +2,7 @@ package generators
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/lerenn/asyncapi-codegen/pkg/asyncapi"
@@ -57,8 +58,7 @@ func GenerateValidateTags[T any](schema asyncapi.Validations[T], isPointer bool,
 
 	directives = appendEnumDirectives(schema, directives)
 	if schema.Const != nil {
-		if cStr, ok := schema.Const.(string); ok {
-			// Only generate enum if the elements is a string, otherwise this is unsupported
+		if cStr, ok := scalarToValidatorValue(schema.Const); ok {
 			directives = append(directives, fmt.Sprintf("eq=%s", cStr))
 		}
 	}
@@ -80,19 +80,44 @@ func singleQuote(s string) string {
 }
 
 func appendEnumDirectives[T any](schema asyncapi.Validations[T], directives []string) []string {
-	if len(schema.Enum) > 0 {
-		var enumsStr []string
-		for _, e := range schema.Enum {
-			if eStr, ok := e.(string); ok {
-				// single quotes are mandatory in order to handle values with spaces
-				enumsStr = append(enumsStr, singleQuote(eStr))
-			}
+	if len(schema.Enum) == 0 {
+		return directives
+	}
+
+	enumsStr := make([]string, 0, len(schema.Enum))
+	for _, e := range schema.Enum {
+		v, ok := scalarToValidatorValue(e)
+		if !ok {
+			// If any element is not a supported scalar, the whole enum is unsupported.
+			return directives
 		}
 
-		// Only generate enum if all elements are string, otherwise this is unsupported
-		if len(schema.Enum) == len(enumsStr) {
-			directives = append(directives, fmt.Sprintf("oneof=%s", strings.Join(enumsStr, " ")))
+		// String values are single-quoted to handle values with spaces.
+		if _, isStr := e.(string); isStr {
+			v = singleQuote(v)
 		}
+		enumsStr = append(enumsStr, v)
 	}
-	return directives
+
+	return append(directives, fmt.Sprintf("oneof=%s", strings.Join(enumsStr, " ")))
+}
+
+// scalarToValidatorValue returns the validator literal for a scalar enum/const
+// value. It reports false when the value is not a supported scalar (object,
+// array, ...), in which case no validation directive should be generated.
+func scalarToValidatorValue(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), true
+	case int:
+		return strconv.Itoa(t), true
+	case int64:
+		return strconv.FormatInt(t, 10), true
+	default:
+		return "", false
+	}
 }

--- a/pkg/codegen/generators/helpers_test.go
+++ b/pkg/codegen/generators/helpers_test.go
@@ -1,0 +1,49 @@
+package generators
+
+import (
+	"testing"
+
+	"github.com/lerenn/asyncapi-codegen/pkg/asyncapi"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGenerateValidateTagsEnum ensures enum validation directives are generated
+// for non-string enums (integers, booleans) and not only for strings (issue
+// #137). JSON numbers are unmarshaled as float64, which is what we test here.
+func TestGenerateValidateTagsEnum(t *testing.T) {
+	cases := map[string]struct {
+		enum     []any
+		expected string
+	}{
+		"string enum": {
+			enum:     []any{"foo", "bar baz"},
+			expected: "oneof='foo' 'bar baz'",
+		},
+		"integer enum": {
+			enum:     []any{float64(1), float64(2), float64(3)},
+			expected: "oneof=1 2 3",
+		},
+		"boolean enum": {
+			enum:     []any{true, false},
+			expected: "oneof=true false",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tag := GenerateValidateTags[any](asyncapi.Validations[any]{
+				Enum: tc.enum,
+			}, false, "string")
+			assert.Contains(t, tag, tc.expected)
+		})
+	}
+}
+
+// TestGenerateValidateTagsConst ensures const validation directives are
+// generated for non-string consts too (issue #137).
+func TestGenerateValidateTagsConst(t *testing.T) {
+	tag := GenerateValidateTags[any](asyncapi.Validations[any]{
+		Const: float64(42),
+	}, false, "integer")
+	assert.Contains(t, tag, "eq=42")
+}


### PR DESCRIPTION
## Issue

Fixes #137 — enum validation was only emitted when **all** enum values were strings; integer and boolean enums (and consts) produced no `validate` tag, so out-of-enum values were never rejected.

## Change

`appendEnumDirectives` and the const handling now format numeric (`float64`/`int`/`int64`) and boolean scalars in addition to strings, producing `oneof=1 2 3` / `oneof=true false` / `eq=42`. String values stay single-quoted to preserve space handling. If any enum element is a non-scalar (object/array), the directive is skipped as before.

## Test

`pkg/codegen/generators/helpers_test.go` exercises `GenerateValidateTags` with string, integer and boolean enums plus a numeric const. The integer/boolean/const cases fail before the change (no directive emitted) and pass after. `go generate ./...` produces no golden-file diff (no existing spec uses non-string enums).

🤖 Generated with [Claude Code](https://claude.com/claude-code)