### PR TITLE
feat(asyncapi): add Follow() to remaining referenceable types (#146)

### DIFF
--- a/pkg/asyncapi/v2/follow_test.go
+++ b/pkg/asyncapi/v2/follow_test.go
@@ -1,0 +1,18 @@
+package asyncapiv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParameterFollow ensures Parameter.Follow returns the referenced parameter
+// when set and the parameter itself otherwise (issue #146).
+func TestParameterFollow(t *testing.T) {
+	p := &Parameter{}
+	assert.Same(t, p, p.Follow())
+
+	target := &Parameter{}
+	ref := &Parameter{ReferenceTo: target}
+	assert.Same(t, target, ref.Follow())
+}

--- a/pkg/asyncapi/v2/parameter.go
+++ b/pkg/asyncapi/v2/parameter.go
@@ -38,3 +38,11 @@ func (p *Parameter) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced Parameter if there is one, otherwise the Parameter itself.
+func (p *Parameter) Follow() *Parameter {
+	if p.ReferenceTo != nil {
+		return p.ReferenceTo
+	}
+	return p
+}

--- a/pkg/asyncapi/v3/channel_bindings.go
+++ b/pkg/asyncapi/v3/channel_bindings.go
@@ -60,3 +60,11 @@ func (chb *ChannelBindings) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced ChannelBindings if there is one, otherwise the ChannelBindings itself.
+func (chb *ChannelBindings) Follow() *ChannelBindings {
+	if chb.ReferenceTo != nil {
+		return chb.ReferenceTo
+	}
+	return chb
+}

--- a/pkg/asyncapi/v3/external_documentation.go
+++ b/pkg/asyncapi/v3/external_documentation.go
@@ -50,3 +50,11 @@ func (doc *ExternalDocumentation) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced ExternalDocumentation if there is one, otherwise the ExternalDocumentation itself.
+func (doc *ExternalDocumentation) Follow() *ExternalDocumentation {
+	if doc.ReferenceTo != nil {
+		return doc.ReferenceTo
+	}
+	return doc
+}

--- a/pkg/asyncapi/v3/follow_test.go
+++ b/pkg/asyncapi/v3/follow_test.go
@@ -1,0 +1,48 @@
+package asyncapiv3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFollowReturnsSelfWithoutReference ensures Follow returns the structure
+// itself when it does not reference another one (issue #146).
+func TestFollowReturnsSelfWithoutReference(t *testing.T) {
+	srv := &Server{}
+	assert.Same(t, srv, srv.Follow())
+
+	tag := &Tag{}
+	assert.Same(t, tag, tag.Follow())
+
+	ex := &MessageExample{}
+	assert.Same(t, ex, ex.Follow())
+
+	ora := &OperationReplyAddress{}
+	assert.Same(t, ora, ora.Follow())
+
+	sec := &SecurityScheme{}
+	assert.Same(t, sec, sec.Follow())
+
+	sv := &ServerVariable{}
+	assert.Same(t, sv, sv.Follow())
+
+	doc := &ExternalDocumentation{}
+	assert.Same(t, doc, doc.Follow())
+}
+
+// TestFollowReturnsReference ensures Follow returns the referenced structure
+// when one is set (issue #146).
+func TestFollowReturnsReference(t *testing.T) {
+	target := &Server{}
+	ref := &Server{ReferenceTo: target}
+	assert.Same(t, target, ref.Follow())
+
+	tagTarget := &Tag{}
+	tagRef := &Tag{ReferenceTo: tagTarget}
+	assert.Same(t, tagTarget, tagRef.Follow())
+
+	secTarget := &SecurityScheme{}
+	secRef := &SecurityScheme{ReferenceTo: secTarget}
+	assert.Same(t, secTarget, secRef.Follow())
+}

--- a/pkg/asyncapi/v3/message_bindings.go
+++ b/pkg/asyncapi/v3/message_bindings.go
@@ -62,3 +62,11 @@ func (mb *MessageBindings) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced MessageBindings if there is one, otherwise the MessageBindings itself.
+func (mb *MessageBindings) Follow() *MessageBindings {
+	if mb.ReferenceTo != nil {
+		return mb.ReferenceTo
+	}
+	return mb
+}

--- a/pkg/asyncapi/v3/message_example.go
+++ b/pkg/asyncapi/v3/message_example.go
@@ -46,3 +46,11 @@ func (me *MessageExample) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced MessageExample if there is one, otherwise the MessageExample itself.
+func (me *MessageExample) Follow() *MessageExample {
+	if me.ReferenceTo != nil {
+		return me.ReferenceTo
+	}
+	return me
+}

--- a/pkg/asyncapi/v3/operation_bindings.go
+++ b/pkg/asyncapi/v3/operation_bindings.go
@@ -62,3 +62,11 @@ func (ob *OperationBindings) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced OperationBindings if there is one, otherwise the OperationBindings itself.
+func (ob *OperationBindings) Follow() *OperationBindings {
+	if ob.ReferenceTo != nil {
+		return ob.ReferenceTo
+	}
+	return ob
+}

--- a/pkg/asyncapi/v3/operation_reply_address.go
+++ b/pkg/asyncapi/v3/operation_reply_address.go
@@ -72,3 +72,11 @@ func (ora OperationReplyAddress) isLocationRequired(op *Operation) (bool, error)
 	path := strings.Split(ora.Location, "/")
 	return locationParent.IsFieldRequired(path[len(path)-1]), nil
 }
+
+// Follow returns the referenced OperationReplyAddress if there is one, otherwise the OperationReplyAddress itself.
+func (ora *OperationReplyAddress) Follow() *OperationReplyAddress {
+	if ora.ReferenceTo != nil {
+		return ora.ReferenceTo
+	}
+	return ora
+}

--- a/pkg/asyncapi/v3/security_scheme.go
+++ b/pkg/asyncapi/v3/security_scheme.go
@@ -119,3 +119,11 @@ func RemoveDuplicateSecuritySchemes(securities []*SecurityScheme) []*SecuritySch
 	}
 	return newList
 }
+
+// Follow returns the referenced SecurityScheme if there is one, otherwise the SecurityScheme itself.
+func (s *SecurityScheme) Follow() *SecurityScheme {
+	if s.ReferenceTo != nil {
+		return s.ReferenceTo
+	}
+	return s
+}

--- a/pkg/asyncapi/v3/server.go
+++ b/pkg/asyncapi/v3/server.go
@@ -123,3 +123,11 @@ func (srv *Server) setReference(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced Server if there is one, otherwise the Server itself.
+func (srv *Server) Follow() *Server {
+	if srv.ReferenceTo != nil {
+		return srv.ReferenceTo
+	}
+	return srv
+}

--- a/pkg/asyncapi/v3/server_bindings.go
+++ b/pkg/asyncapi/v3/server_bindings.go
@@ -62,3 +62,11 @@ func (ob *ServerBindings) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced ServerBindings if there is one, otherwise the ServerBindings itself.
+func (ob *ServerBindings) Follow() *ServerBindings {
+	if ob.ReferenceTo != nil {
+		return ob.ReferenceTo
+	}
+	return ob
+}

--- a/pkg/asyncapi/v3/server_variable.go
+++ b/pkg/asyncapi/v3/server_variable.go
@@ -47,3 +47,11 @@ func (sv *ServerVariable) setDependencies(spec Specification) error {
 
 	return nil
 }
+
+// Follow returns the referenced ServerVariable if there is one, otherwise the ServerVariable itself.
+func (sv *ServerVariable) Follow() *ServerVariable {
+	if sv.ReferenceTo != nil {
+		return sv.ReferenceTo
+	}
+	return sv
+}

--- a/pkg/asyncapi/v3/tag.go
+++ b/pkg/asyncapi/v3/tag.go
@@ -72,3 +72,11 @@ func RemoveDuplicateTags(tags []*Tag) []*Tag {
 	}
 	return newList
 }
+
+// Follow returns the referenced Tag if there is one, otherwise the Tag itself.
+func (t *Tag) Follow() *Tag {
+	if t.ReferenceTo != nil {
+		return t.ReferenceTo
+	}
+	return t
+}


### PR DESCRIPTION
## Issue

Fixes #146 — only some referenceable structures exposed a `Follow()` helper to resolve a `$ref`. Many v3 types with a `ReferenceTo` field (and v2 `Parameter`) lacked one, so callers had to special-case them.

## Change

Adds a `Follow()` method (returns the referenced value if set, otherwise the receiver) to every remaining type that has a `ReferenceTo`:

- **v3**: `ChannelBindings`, `ExternalDocumentation`, `MessageBindings`, `MessageExample`, `OperationBindings`, `OperationReplyAddress`, `SecurityScheme`, `Server`, `ServerBindings`, `ServerVariable`, `Tag`
- **v2**: `Parameter`

This matches the pattern already used by `Channel`, `Message`, `Operation`, `Schema`, etc. Purely additive — `go generate ./...` produces no diff. (`CorrelationID.ReferenceTo` is typed `*Channel`, an anomaly left untouched here.)

## Test

`pkg/asyncapi/v3/follow_test.go` and `pkg/asyncapi/v2/follow_test.go` assert `Follow()` returns the receiver when there is no reference and the referent when one is set. They fail to compile before the change (methods undefined) and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)