### PR TITLE
feat(extensions): add LogInfosFromContext helper (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,17 @@ ctrl, _ := NewAppController(
 )
 ```
 
+The controller stores contextual information (channel, correlation ID,
+direction, …) in the `context.Context` passed to your logger. To retrieve it
+without unwrapping each key manually, use `extensions.LogInfosFromContext`:
+
+```golang
+func (logger SimpleLogger) Info(ctx context.Context, msg string, info ...extensions.LogInfo) {
+  info = append(info, extensions.LogInfosFromContext(ctx)...)
+  // ... log msg with info
+}
+```
+
 ### Versioning
 
 If you are in need to do a migration or support multiple versions of your

--- a/pkg/extensions/logger.go
+++ b/pkg/extensions/logger.go
@@ -8,6 +8,31 @@ type LogInfo struct {
 	Value any
 }
 
+// LogInfosFromContext extracts the asyncapi-codegen values carried in the
+// context (provider, channel, direction, correlation ID, broker message and
+// specification version) into a slice of LogInfo.
+//
+// It is a convenience for custom Logger implementations that want this
+// information without having to know and unwrap each context key individually.
+func LogInfosFromContext(ctx context.Context) []LogInfo {
+	var infos []LogInfo
+
+	add := func(key string, ctxKey ContextKey) {
+		IfContextSetWith(ctx, ctxKey, func(value any) {
+			infos = append(infos, LogInfo{Key: key, Value: value})
+		})
+	}
+
+	add("version", ContextKeyIsVersion)
+	add("provider", ContextKeyIsProvider)
+	add("channel", ContextKeyIsChannel)
+	add("direction", ContextKeyIsDirection)
+	add("correlationID", ContextKeyIsCorrelationID)
+	add("brokerMessage", ContextKeyIsBrokerMessage)
+
+	return infos
+}
+
 // Logger is the interface that must be implemented by a logger.
 type Logger interface {
 	// Info logs information based on a message and key-value elements

--- a/pkg/extensions/logger_test.go
+++ b/pkg/extensions/logger_test.go
@@ -1,0 +1,36 @@
+package extensions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLogInfosFromContext ensures the helper extracts the asyncapi-codegen
+// context values into LogInfo entries, and only the ones that are set (#133).
+func TestLogInfosFromContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ContextKeyIsChannel, "my-channel")
+	ctx = context.WithValue(ctx, ContextKeyIsCorrelationID, "corr-1")
+
+	infos := LogInfosFromContext(ctx)
+
+	got := make(map[string]any, len(infos))
+	for _, info := range infos {
+		got[info.Key] = info.Value
+	}
+
+	assert.Equal(t, "my-channel", got["channel"])
+	assert.Equal(t, "corr-1", got["correlationID"])
+
+	// Values that were not set must not be present.
+	_, hasProvider := got["provider"]
+	assert.False(t, hasProvider)
+	assert.Len(t, infos, 2)
+}
+
+// TestLogInfosFromContextEmpty ensures an empty context yields no LogInfo.
+func TestLogInfosFromContextEmpty(t *testing.T) {
+	assert.Empty(t, LogInfosFromContext(context.Background()))
+}


### PR DESCRIPTION
## Issue

Addresses #133 — the controller stores contextual information (channel, correlation ID, direction, …) in the `context.Context`, and the built-in loggers unwrap it. A **custom** logger had to know and unwrap each context key itself, which the issue calls out as tedious.

## Change

Adds `extensions.LogInfosFromContext(ctx) []LogInfo`, which extracts all the asyncapi-codegen context values (provider, channel, direction, correlation ID, broker message, version) that are set into a `[]LogInfo` in a single call. A custom logger can simply append them:

```go
func (l MyLogger) Info(ctx context.Context, msg string, info ...extensions.LogInfo) {
    info = append(info, extensions.LogInfosFromContext(ctx)...)
    // ...
}
```

This is non-breaking and additive. The full refactor proposed in the issue (passing everything as explicit arguments from the generated code and dropping context enrichment from the built-in loggers) is a breaking, repo-wide change and is intentionally **left out** of this PR — hence "Addresses" rather than "Fixes".

## Test

`pkg/extensions/logger_test.go` asserts the helper returns a `LogInfo` for each value present (and only those), and nothing for an empty context. It fails to compile before the change (function undefined) and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)