### PR TITLE
feat(extensions): pass log infos explicitly instead of via context (#334)

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,16 +594,34 @@ ctrl, _ := NewAppController(
 )
 ```
 
-The controller stores contextual information (channel, correlation ID,
-direction, …) in the `context.Context` passed to your logger. To retrieve it
-without unwrapping each key manually, use `extensions.LogInfosFromContext`:
+The generated code passes the contextual information (channel, correlation ID,
+direction, provider, broker message, version) directly to your logger as
+explicit `LogInfo` arguments at every log call. Your logger therefore only has
+to log the `msg` and the `info` it is given — there is no need to unwrap any
+context key:
 
 ```golang
 func (logger SimpleLogger) Info(ctx context.Context, msg string, info ...extensions.LogInfo) {
-  info = append(info, extensions.LogInfosFromContext(ctx)...)
+  // 'info' already contains the contextual values (channel, correlationID, …)
   // ... log msg with info
 }
 ```
+
+> **Migration note (from versions where loggers enriched from context):** the
+> contextual values are no longer read from the `context.Context` by the
+> built-in `Text`/`ECS` loggers — they are now supplied as explicit `LogInfo`
+> arguments by the generated code, using the generic keys returned by
+> `extensions.LogInfosFromContext` (`channel`, `correlationID`, `brokerMessage`,
+> `direction`, `provider`, `version`). This means:
+> * The built-in `Text` and `ECS` loggers now emit those generic keys instead of
+>   their previous custom names (e.g. ECS no longer maps to `trace.id`,
+>   `event.action`, `event.original`).
+> * Custom loggers receive everything as arguments and no longer need to call
+>   `extensions.LogInfosFromContext` themselves.
+>
+> The values are still stored in the `context.Context` (it stays useful for
+> other purposes), so a custom logger that *wants* to keep reading from context
+> can still call `extensions.LogInfosFromContext(ctx)`.
 
 ### Versioning
 

--- a/examples/helloworld/v2/nats/app/app.gen.go
+++ b/examples/helloworld/v2/nats/app/app.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -195,17 +195,17 @@ func (c *AppController) SubscribeHello(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -213,7 +213,7 @@ func (c *AppController) SubscribeHello(
 			// Listen to next message
 			stop, err := c.listenToHelloNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -299,7 +299,7 @@ func (c *AppController) UnsubscribeHello(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/examples/helloworld/v3/nats/app/app.gen.go
+++ b/examples/helloworld/v3/nats/app/app.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -201,17 +201,17 @@ func (c *AppController) SubscribeToReceiveHelloOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -219,7 +219,7 @@ func (c *AppController) SubscribeToReceiveHelloOperation(
 			// Listen to next message
 			stop, err := c.listenToReceiveHelloOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -307,7 +307,7 @@ func (c *AppController) UnsubscribeFromReceiveHelloOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/examples/ping/v2/kafka/app/app.gen.go
+++ b/examples/ping/v2/kafka/app/app.gen.go
@@ -159,7 +159,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -199,17 +199,17 @@ func (c *AppController) SubscribePing(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -217,7 +217,7 @@ func (c *AppController) SubscribePing(
 			// Listen to next message
 			stop, err := c.listenToPingNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribePing(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishPong will publish messages to 'pong.v2' channel

--- a/examples/ping/v2/kafka/user/user.gen.go
+++ b/examples/ping/v2/kafka/user/user.gen.go
@@ -159,7 +159,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -199,17 +199,17 @@ func (c *UserController) SubscribePong(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -217,7 +217,7 @@ func (c *UserController) SubscribePong(
 			// Listen to next message
 			stop, err := c.listenToPongNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *UserController) UnsubscribePong(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishPing will publish messages to 'ping.v2' channel
@@ -365,10 +365,10 @@ func (c *UserController) WaitForPong(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close subscriber on leave
 	defer func() {
@@ -376,7 +376,7 @@ func (c *UserController) WaitForPong(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Execute callback for publication
@@ -391,7 +391,7 @@ func (c *UserController) WaitForPong(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -423,14 +423,14 @@ func (c *UserController) waitForPongNextMessage(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		msg, err := brokerMessageToPongMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge message
@@ -457,7 +457,7 @@ func (c *UserController) waitForPongNextMessage(
 
 		return &msg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/examples/ping/v2/nats-jetstream/app/app.gen.go
+++ b/examples/ping/v2/nats-jetstream/app/app.gen.go
@@ -159,7 +159,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -199,17 +199,17 @@ func (c *AppController) SubscribePing(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -217,7 +217,7 @@ func (c *AppController) SubscribePing(
 			// Listen to next message
 			stop, err := c.listenToPingNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribePing(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishPong will publish messages to 'pong.v2' channel

--- a/examples/ping/v2/nats-jetstream/user/user.gen.go
+++ b/examples/ping/v2/nats-jetstream/user/user.gen.go
@@ -159,7 +159,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -199,17 +199,17 @@ func (c *UserController) SubscribePong(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -217,7 +217,7 @@ func (c *UserController) SubscribePong(
 			// Listen to next message
 			stop, err := c.listenToPongNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *UserController) UnsubscribePong(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishPing will publish messages to 'ping.v2' channel
@@ -365,10 +365,10 @@ func (c *UserController) WaitForPong(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close subscriber on leave
 	defer func() {
@@ -376,7 +376,7 @@ func (c *UserController) WaitForPong(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Execute callback for publication
@@ -391,7 +391,7 @@ func (c *UserController) WaitForPong(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -423,14 +423,14 @@ func (c *UserController) waitForPongNextMessage(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		msg, err := brokerMessageToPongMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge message
@@ -457,7 +457,7 @@ func (c *UserController) waitForPongNextMessage(
 
 		return &msg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/examples/ping/v2/nats/app/app.gen.go
+++ b/examples/ping/v2/nats/app/app.gen.go
@@ -159,7 +159,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -199,17 +199,17 @@ func (c *AppController) SubscribePing(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -217,7 +217,7 @@ func (c *AppController) SubscribePing(
 			// Listen to next message
 			stop, err := c.listenToPingNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribePing(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishPong will publish messages to 'pong.v2' channel

--- a/examples/ping/v2/nats/user/user.gen.go
+++ b/examples/ping/v2/nats/user/user.gen.go
@@ -159,7 +159,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -199,17 +199,17 @@ func (c *UserController) SubscribePong(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -217,7 +217,7 @@ func (c *UserController) SubscribePong(
 			// Listen to next message
 			stop, err := c.listenToPongNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *UserController) UnsubscribePong(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishPing will publish messages to 'ping.v2' channel
@@ -365,10 +365,10 @@ func (c *UserController) WaitForPong(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close subscriber on leave
 	defer func() {
@@ -376,7 +376,7 @@ func (c *UserController) WaitForPong(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Execute callback for publication
@@ -391,7 +391,7 @@ func (c *UserController) WaitForPong(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -423,14 +423,14 @@ func (c *UserController) waitForPongNextMessage(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		msg, err := brokerMessageToPongMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge message
@@ -457,7 +457,7 @@ func (c *UserController) waitForPongNextMessage(
 
 		return &msg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/examples/ping/v3/kafka/app/app.gen.go
+++ b/examples/ping/v3/kafka/app/app.gen.go
@@ -158,7 +158,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -204,17 +204,17 @@ func (c *AppController) SubscribeToPingRequestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -222,7 +222,7 @@ func (c *AppController) SubscribeToPingRequestOperation(
 			// Listen to next message
 			stop, err := c.listenToPingRequestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -329,7 +329,7 @@ func (c *AppController) UnsubscribeFromPingRequestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingRequestOperation will send a Pong message on Pong channel.
@@ -345,7 +345,7 @@ func (c *AppController) SendAsReplyToPingRequestOperation(
 
 	// Set correlation ID if it does not exist
 	if id := msg.CorrelationID(); id == "" {
-		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error())
+		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error(), extensions.LogInfosFromContext(ctx)...)
 		return extensions.ErrNoCorrelationIDSet
 
 	}

--- a/examples/ping/v3/kafka/user/user.gen.go
+++ b/examples/ping/v3/kafka/user/user.gen.go
@@ -211,10 +211,10 @@ func (c *UserController) RequestToPingRequestOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -222,7 +222,7 @@ func (c *UserController) RequestToPingRequestOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Set correlation ID if it does not exist
@@ -232,7 +232,7 @@ func (c *UserController) RequestToPingRequestOperation(
 
 	// Send the message
 	if err := c.SendToPingRequestOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -243,7 +243,7 @@ func (c *UserController) RequestToPingRequestOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -275,14 +275,14 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		rmsg, err := brokerMessageToPongMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge the message
@@ -312,7 +312,7 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/examples/ping/v3/nats-jetstream/app/app.gen.go
+++ b/examples/ping/v3/nats-jetstream/app/app.gen.go
@@ -158,7 +158,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -204,17 +204,17 @@ func (c *AppController) SubscribeToPingRequestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -222,7 +222,7 @@ func (c *AppController) SubscribeToPingRequestOperation(
 			// Listen to next message
 			stop, err := c.listenToPingRequestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -329,7 +329,7 @@ func (c *AppController) UnsubscribeFromPingRequestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingRequestOperation will send a Pong message on Pong channel.
@@ -345,7 +345,7 @@ func (c *AppController) SendAsReplyToPingRequestOperation(
 
 	// Set correlation ID if it does not exist
 	if id := msg.CorrelationID(); id == "" {
-		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error())
+		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error(), extensions.LogInfosFromContext(ctx)...)
 		return extensions.ErrNoCorrelationIDSet
 
 	}

--- a/examples/ping/v3/nats-jetstream/user/user.gen.go
+++ b/examples/ping/v3/nats-jetstream/user/user.gen.go
@@ -211,10 +211,10 @@ func (c *UserController) RequestToPingRequestOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -222,7 +222,7 @@ func (c *UserController) RequestToPingRequestOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Set correlation ID if it does not exist
@@ -232,7 +232,7 @@ func (c *UserController) RequestToPingRequestOperation(
 
 	// Send the message
 	if err := c.SendToPingRequestOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -243,7 +243,7 @@ func (c *UserController) RequestToPingRequestOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -275,14 +275,14 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		rmsg, err := brokerMessageToPongMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge the message
@@ -312,7 +312,7 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/examples/ping/v3/nats/app/app.gen.go
+++ b/examples/ping/v3/nats/app/app.gen.go
@@ -158,7 +158,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -204,17 +204,17 @@ func (c *AppController) SubscribeToPingRequestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -222,7 +222,7 @@ func (c *AppController) SubscribeToPingRequestOperation(
 			// Listen to next message
 			stop, err := c.listenToPingRequestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -329,7 +329,7 @@ func (c *AppController) UnsubscribeFromPingRequestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingRequestOperation will send a Pong message on Pong channel.
@@ -345,7 +345,7 @@ func (c *AppController) SendAsReplyToPingRequestOperation(
 
 	// Set correlation ID if it does not exist
 	if id := msg.CorrelationID(); id == "" {
-		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error())
+		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error(), extensions.LogInfosFromContext(ctx)...)
 		return extensions.ErrNoCorrelationIDSet
 
 	}

--- a/examples/ping/v3/nats/user/user.gen.go
+++ b/examples/ping/v3/nats/user/user.gen.go
@@ -211,10 +211,10 @@ func (c *UserController) RequestToPingRequestOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -222,7 +222,7 @@ func (c *UserController) RequestToPingRequestOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Set correlation ID if it does not exist
@@ -232,7 +232,7 @@ func (c *UserController) RequestToPingRequestOperation(
 
 	// Send the message
 	if err := c.SendToPingRequestOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -243,7 +243,7 @@ func (c *UserController) RequestToPingRequestOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -275,14 +275,14 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		rmsg, err := brokerMessageToPongMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge the message
@@ -312,7 +312,7 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/pkg/codegen/generators/v2/templates/controller.tmpl
+++ b/pkg/codegen/generators/v2/templates/controller.tmpl
@@ -97,7 +97,7 @@ func (c *{{ .Prefix }}Controller) Close(ctx context.Context) {
 {{if .MethodCount -}}
     c.UnsubscribeAll(ctx)
 
-    c.logger.Info(ctx, "Closed {{ snakeCase .Prefix }} controller")
+    c.logger.Info(ctx, "Closed {{ snakeCase .Prefix }} controller", extensions.LogInfosFromContext(ctx)...)
 {{end -}}
 }
 
@@ -152,17 +152,17 @@ func (c *{{ $.Prefix }}Controller) Subscribe{{operationName $value}}(
     _, exists := c.subscriptions[path]
     if exists {
         err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-        c.logger.Error(ctx, err.Error())
+        c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
         return err
     }
 
     // Subscribe to broker channel
     sub, err := c.broker.Subscribe(ctx, path)
     if err != nil {
-        c.logger.Error(ctx, err.Error())
+        c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
         return err
     }
-    c.logger.Info(ctx, "Subscribed to channel")
+    c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
     // Asynchronously listen to new messages and pass them to app subscriber
     go func() {
@@ -170,7 +170,7 @@ func (c *{{ $.Prefix }}Controller) Subscribe{{operationName $value}}(
             // Listen to next message
             stop, err := c.listenTo{{operationName $value}}NextMessage(path, sub, fn)
             if err != nil {
-                c.logger.Error(ctx, err.Error())
+                c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
             }
 
             // Stop if required
@@ -267,7 +267,7 @@ func (c *{{ $.Prefix }}Controller) Unsubscribe{{operationName $value}}(ctx conte
     // Remove if from the subscribers
     delete(c.subscriptions, path)
 
-    c.logger.Info(ctx, "Unsubscribed from channel")
+    c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 {{end}}
 
@@ -340,10 +340,10 @@ func (c *UserController) WaitFor{{operationName $value}}(
     // Subscribe to broker channel
     sub, err := c.broker.Subscribe(ctx, path)
     if err != nil {
-        c.logger.Error(ctx, err.Error())
+        c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
         return {{(channelToMessage $value "subscribe").Name}}{}, err
     }
-    c.logger.Info(ctx, "Subscribed to channel")
+    c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
     // Close subscriber on leave
     defer func(){
@@ -351,7 +351,7 @@ func (c *UserController) WaitFor{{operationName $value}}(
         sub.Cancel(ctx)
 
         // Logging unsubscribing
-        c.logger.Info(ctx, "Unsubscribed from channel")
+        c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
     } ()
 
     // Execute callback for publication
@@ -366,7 +366,7 @@ func (c *UserController) WaitFor{{operationName $value}}(
         if err != nil {
             // Return on error (e.g. context canceled or subscription closed)
             // instead of looping forever
-            c.logger.Error(ctx, err.Error())
+            c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
             return {{(channelToMessage $value "subscribe").Name}}{}, err
         }
 
@@ -398,14 +398,14 @@ func (c *UserController) waitFor{{operationName $value}}NextMessage(
         // (i.e. uninitialized message), then the subscription ended before
         // receiving the expected message
         if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-            c.logger.Error(msgCtx, "Channel closed before getting message")
+            c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
             return nil, extensions.ErrSubscriptionCanceled
         }
 
         // Get new message
         msg, err := brokerMessageTo{{(channelToMessage $value "subscribe").Name}}(acknowledgeableBrokerMessage.BrokerMessage)
         if err != nil {
-            c.logger.Error(msgCtx, err.Error())
+            c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
         }
 
         // Acknowledge message
@@ -432,7 +432,7 @@ func (c *UserController) waitFor{{operationName $value}}NextMessage(
 
         return &msg, nil
     case <-ctx.Done(): // Set corresponding error if context is done
-        c.logger.Error(msgCtx, "Context done before getting message")
+        c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
         return nil, extensions.ErrContextCanceled
     }
 }

--- a/pkg/codegen/generators/v3/templates/controller.tmpl
+++ b/pkg/codegen/generators/v3/templates/controller.tmpl
@@ -97,7 +97,7 @@ func (c *{{ .Prefix }}Controller) Close(ctx context.Context) {
 {{if .Operations.ReceiveCount -}}
     c.UnsubscribeFromAllChannels(ctx)
 
-    c.logger.Info(ctx, "Closed {{ snakeCase .Prefix }} controller")
+    c.logger.Info(ctx, "Closed {{ snakeCase .Prefix }} controller", extensions.LogInfosFromContext(ctx)...)
 {{end -}}
 }
 
@@ -158,17 +158,17 @@ func (c *{{ $.Prefix }}Controller) {{ subscribeFuncName $value }}(
     _, exists := c.subscriptions[addr]
     if exists {
         err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-        c.logger.Error(ctx, err.Error())
+        c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
         return err
     }
 
     // Subscribe to broker channel
     sub, err := c.broker.Subscribe(ctx, addr)
     if err != nil {
-        c.logger.Error(ctx, err.Error())
+        c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
         return err
     }
-    c.logger.Info(ctx, "Subscribed to channel")
+    c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
     // Asynchronously listen to new messages and pass them to app receiver
     go func() {
@@ -176,7 +176,7 @@ func (c *{{ $.Prefix }}Controller) {{ subscribeFuncName $value }}(
             // Listen to next message
             stop, err := c.listenTo{{ namify $value.Follow.Name }}NextMessage(addr, sub, fn)
             if err != nil {
-                c.logger.Error(ctx, err.Error())
+                c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
             }
 
             // Stop if required
@@ -307,7 +307,7 @@ func (c *{{ $.Prefix }}Controller) UnsubscribeFrom{{ namify $value.Follow.Name }
     // Remove if from the receivers
     delete(c.subscriptions, addr)
 
-    c.logger.Info(ctx, "Unsubscribed from channel")
+    c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 {{- end}}
 
@@ -394,7 +394,7 @@ func (c *{{ $.Prefix }}Controller) {{ sendFuncName $value $.Prefix }}(
     // Set correlation ID if it does not exist
     if id := msg.CorrelationID(); id == "" {
         {{if .ReplyOf -}}
-        c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error())
+        c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error(), extensions.LogInfosFromContext(ctx)...)
         return extensions.ErrNoCorrelationIDSet
         {{else -}}
         msg.SetCorrelationID(uuid.New().String())
@@ -464,10 +464,10 @@ func (c *{{ $.Prefix }}Controller) {{ requestFuncName $value $.Prefix }}(
     // Subscribe to broker channel
     sub, err := c.broker.Subscribe(ctx, addr)
     if err != nil {
-        c.logger.Error(ctx, err.Error())
+        c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
         return {{channelToMessageTypeName .Reply.Channel}}{}, err
     }
-    c.logger.Info(ctx, "Subscribed to channel")
+    c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
     // Close receiver on leave
     defer func(){
@@ -475,7 +475,7 @@ func (c *{{ $.Prefix }}Controller) {{ requestFuncName $value $.Prefix }}(
         sub.Cancel(ctx)
 
         // Logging unsubscribing
-        c.logger.Info(ctx, "Unsubscribed from channel")
+        c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
     } ()
 
     {{if $value.GetMessage.HaveCorrelationID -}}
@@ -487,7 +487,7 @@ func (c *{{ $.Prefix }}Controller) {{ requestFuncName $value $.Prefix }}(
 
     // Send the message 
     if err := c.{{ sendFuncName $value $.Prefix }}(ctx, {{- if .Channel.Follow.Parameters}}params,{{- end}} msg); err != nil {
-        c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+        c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
         return {{channelToMessageTypeName .Reply.Channel}}{}, fmt.Errorf("error happened when sending message: %w", err)
     }
 
@@ -498,7 +498,7 @@ func (c *{{ $.Prefix }}Controller) {{ requestFuncName $value $.Prefix }}(
         if err != nil {
             // Return on error (e.g. context canceled or subscription closed)
             // instead of looping forever
-            c.logger.Error(ctx, err.Error())
+            c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
             return {{channelToMessageTypeName .Reply.Channel}}{}, err
         }
 
@@ -534,7 +534,7 @@ func (c *{{ $.Prefix }}Controller) waitFor{{ namify $value.Follow.Name }}NextRes
         // (i.e. uninitialized message), then the subscription ended before
         // receiving the expected message
         if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-            c.logger.Error(msgCtx, "Channel closed before getting message")
+            c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
             return nil, extensions.ErrSubscriptionCanceled
         }
 
@@ -542,7 +542,7 @@ func (c *{{ $.Prefix }}Controller) waitFor{{ namify $value.Follow.Name }}NextRes
         // Get new message
         rmsg, err := brokerMessageTo{{channelToMessageTypeName .Reply.Channel}}(acknowledgeableBrokerMessage.BrokerMessage)
         if err != nil {
-            c.logger.Error(msgCtx, err.Error())
+            c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
         }
 
         // Acknowledge the message
@@ -576,7 +576,7 @@ func (c *{{ $.Prefix }}Controller) waitFor{{ namify $value.Follow.Name }}NextRes
 
         return &rmsg, nil
     case <-ctx.Done(): // Set corresponding error if context is done
-        c.logger.Error(msgCtx, "Context done before getting message")
+        c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
         return nil, extensions.ErrContextCanceled
     }
 }

--- a/pkg/extensions/loggers/ecs.go
+++ b/pkg/extensions/loggers/ecs.go
@@ -27,28 +27,7 @@ func (ecs *ECS) setLevel(level Level) {
 	ecs.level = level
 }
 
-func (ecs ECS) setInfoFromContext(ctx context.Context, msg string, info ...extensions.LogInfo) []extensions.LogInfo {
-	// Add additional keys from context
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsProvider, func(value any) {
-		info = append(info, extensions.LogInfo{Key: "asyncapi.provider", Value: value})
-	})
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsChannel, func(value any) {
-		info = append(info, extensions.LogInfo{Key: "asyncapi.channel", Value: value})
-	})
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsDirection, func(value any) {
-		if value == "publication" {
-			info = append(info, extensions.LogInfo{Key: "event.action", Value: "published-message"})
-		} else if value == "reception" {
-			info = append(info, extensions.LogInfo{Key: "event.action", Value: "received-message"})
-		}
-	})
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsBrokerMessage, func(value any) {
-		info = append(info, extensions.LogInfo{Key: "event.original", Value: value})
-	})
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsCorrelationID, func(value any) {
-		info = append(info, extensions.LogInfo{Key: "trace.id", Value: value})
-	})
-
+func (ecs ECS) addStandardInfo(msg string, info ...extensions.LogInfo) []extensions.LogInfo {
 	// Add additional keys
 	info = append(info, extensions.LogInfo{
 		Key:   "message",
@@ -67,9 +46,9 @@ func (ecs ECS) setInfoFromContext(ctx context.Context, msg string, info ...exten
 	return info
 }
 
-func (ecs ECS) formatLog(ctx context.Context, msg string, info ...extensions.LogInfo) string {
+func (ecs ECS) formatLog(msg string, info ...extensions.LogInfo) string {
 	// Set additional fields
-	info = ecs.setInfoFromContext(ctx, msg, info...)
+	info = ecs.addStandardInfo(msg, info...)
 
 	// Structure log
 	sl := structureLogs(info)
@@ -83,31 +62,31 @@ func (ecs ECS) formatLog(ctx context.Context, msg string, info ...extensions.Log
 	return string(b)
 }
 
-func (ecs ECS) logWithLevel(ctx context.Context, level string, msg string, info ...extensions.LogInfo) {
+func (ecs ECS) logWithLevel(level string, msg string, info ...extensions.LogInfo) {
 	// Add additional keys
 	info = append(info, extensions.LogInfo{Key: "log.level", Value: level})
 
 	// Print log
-	fmt.Println(ecs.formatLog(ctx, msg, info...))
+	fmt.Println(ecs.formatLog(msg, info...))
 }
 
 // Info logs a message at info level with context and additional info.
-func (ecs ECS) Info(ctx context.Context, msg string, info ...extensions.LogInfo) {
+func (ecs ECS) Info(_ context.Context, msg string, info ...extensions.LogInfo) {
 	if ecs.level > LevelInfo {
 		return
 	}
-	ecs.logWithLevel(ctx, "info", msg, info...)
+	ecs.logWithLevel("info", msg, info...)
 }
 
 // Warning logs a message at warning level with context and additional info.
-func (ecs ECS) Warning(ctx context.Context, msg string, info ...extensions.LogInfo) {
+func (ecs ECS) Warning(_ context.Context, msg string, info ...extensions.LogInfo) {
 	if ecs.level > LevelWarning {
 		return
 	}
-	ecs.logWithLevel(ctx, "warning", msg, info...)
+	ecs.logWithLevel("warning", msg, info...)
 }
 
 // Error logs a message at error level with context and additional info.
-func (ecs ECS) Error(ctx context.Context, msg string, info ...extensions.LogInfo) {
-	ecs.logWithLevel(ctx, "error", msg, info...)
+func (ecs ECS) Error(_ context.Context, msg string, info ...extensions.LogInfo) {
+	ecs.logWithLevel("error", msg, info...)
 }

--- a/pkg/extensions/loggers/passthrough_test.go
+++ b/pkg/extensions/loggers/passthrough_test.go
@@ -1,0 +1,77 @@
+package loggers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/lerenn/asyncapi-codegen/pkg/extensions"
+	"github.com/stretchr/testify/assert"
+)
+
+// contextWithAllValues returns a context carrying all the asyncapi-codegen
+// values that the loggers used to enrich from (#334).
+func contextWithAllValues() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, extensions.ContextKeyIsChannel, "my-channel")
+	ctx = context.WithValue(ctx, extensions.ContextKeyIsCorrelationID, "corr-1")
+	ctx = context.WithValue(ctx, extensions.ContextKeyIsProvider, "my-provider")
+	ctx = context.WithValue(ctx, extensions.ContextKeyIsDirection, "publication")
+	ctx = context.WithValue(ctx, extensions.ContextKeyIsBrokerMessage, "the-message")
+	return ctx
+}
+
+// TestECSDoesNotReadFromContext ensures the ECS logger no longer enriches its
+// output from the context: only the explicitly-given LogInfo (plus the
+// intrinsic message/timestamp/logger keys) must be present (#334).
+func TestECSDoesNotReadFromContext(t *testing.T) {
+	ecs := NewECS()
+
+	out := ecs.formatLog("hello", extensions.LogInfo{Key: "given", Value: "value"})
+
+	var got map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	// Explicitly-given info and intrinsic keys are present.
+	assert.Equal(t, "value", got["given"])
+	assert.Equal(t, "hello", got["message"])
+	assert.Contains(t, got, "@timestamp")
+	assert.Contains(t, got, "log")
+
+	// Context-derived keys from the previous behavior must NOT appear, since
+	// the logger no longer reads from any context.
+	assert.NotContains(t, out, "trace.id")
+	assert.NotContains(t, out, "event.action")
+	assert.NotContains(t, out, "event.original")
+	assert.NotContains(t, out, "asyncapi.channel")
+	assert.NotContains(t, out, "asyncapi.provider")
+}
+
+// TestTextDoesNotReadFromContext ensures the Text logger no longer enriches its
+// output from the context (#334).
+func TestTextDoesNotReadFromContext(t *testing.T) {
+	text := NewText()
+
+	out := text.formatLog(text.boldWhitePrinter, "hello", extensions.LogInfo{Key: "given", Value: "value"})
+
+	// Explicitly-given info and the message are present.
+	assert.True(t, strings.Contains(out, "given"))
+	assert.True(t, strings.Contains(out, "hello"))
+
+	// Context-derived keys from the previous behavior must NOT appear.
+	assert.False(t, strings.Contains(out, "Channel"))
+	assert.False(t, strings.Contains(out, "CorrelationID"))
+	assert.False(t, strings.Contains(out, "Content"))
+}
+
+// TestLoggersIgnoreContext is a guard ensuring that passing a fully-populated
+// context to the public logging methods does not leak context values into the
+// output (#334).
+func TestLoggersIgnoreContext(t *testing.T) {
+	ctx := contextWithAllValues()
+
+	// These must not panic and must not read from the context.
+	NewECS().Info(ctx, "msg")
+	NewText().Info(ctx, "msg")
+}

--- a/pkg/extensions/loggers/text.go
+++ b/pkg/extensions/loggers/text.go
@@ -76,18 +76,7 @@ func (tl Text) humanizeStructuredLogs(sl map[string]any, msgFmt *color.Color, pr
 	return s
 }
 
-func (tl Text) setInfoFromContext(ctx context.Context, msg string, info ...extensions.LogInfo) []extensions.LogInfo {
-	// Add additional keys from context
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsChannel, func(value any) {
-		info = append(info, extensions.LogInfo{Key: "Channel", Value: value})
-	})
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsCorrelationID, func(value any) {
-		info = append(info, extensions.LogInfo{Key: "CorrelationID", Value: value})
-	})
-	extensions.IfContextSetWith(ctx, extensions.ContextKeyIsBrokerMessage, func(value any) {
-		info = append(info, extensions.LogInfo{Key: "Content", Value: value})
-	})
-
+func (tl Text) addStandardInfo(msg string, info ...extensions.LogInfo) []extensions.LogInfo {
 	// Add additional keys
 	info = append(info, extensions.LogInfo{
 		Key:   "Message",
@@ -102,9 +91,9 @@ func (tl Text) setInfoFromContext(ctx context.Context, msg string, info ...exten
 	return info
 }
 
-func (tl Text) formatLog(ctx context.Context, msgFmt *color.Color, msg string, info ...extensions.LogInfo) string {
+func (tl Text) formatLog(msgFmt *color.Color, msg string, info ...extensions.LogInfo) string {
 	// Set additional fields
-	info = tl.setInfoFromContext(ctx, msg, info...)
+	info = tl.addStandardInfo(msg, info...)
 
 	// Structure log
 	sl := structureLogs(info)
@@ -114,22 +103,22 @@ func (tl Text) formatLog(ctx context.Context, msgFmt *color.Color, msg string, i
 }
 
 // Info logs a message at info level with context and additional info.
-func (tl Text) Info(ctx context.Context, msg string, info ...extensions.LogInfo) {
+func (tl Text) Info(_ context.Context, msg string, info ...extensions.LogInfo) {
 	if tl.level > LevelInfo {
 		return
 	}
-	fmt.Println(tl.formatLog(ctx, tl.boldWhitePrinter, msg, info...))
+	fmt.Println(tl.formatLog(tl.boldWhitePrinter, msg, info...))
 }
 
 // Warning logs a message at warning level with context and additional info.
-func (tl Text) Warning(ctx context.Context, msg string, info ...extensions.LogInfo) {
+func (tl Text) Warning(_ context.Context, msg string, info ...extensions.LogInfo) {
 	if tl.level > LevelWarning {
 		return
 	}
-	fmt.Println(tl.formatLog(ctx, tl.boldOrangePrinter, msg, info...))
+	fmt.Println(tl.formatLog(tl.boldOrangePrinter, msg, info...))
 }
 
 // Error logs a message at error level with context and additional info.
-func (tl Text) Error(ctx context.Context, msg string, info ...extensions.LogInfo) {
-	fmt.Println(tl.formatLog(ctx, tl.boldRedPrinter, msg, info...))
+func (tl Text) Error(_ context.Context, msg string, info ...extensions.LogInfo) {
+	fmt.Println(tl.formatLog(tl.boldRedPrinter, msg, info...))
 }

--- a/test/v2/issues/101/asyncapi.gen.go
+++ b/test/v2/issues/101/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -195,17 +195,17 @@ func (c *AppController) SubscribeV2Issue101Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -213,7 +213,7 @@ func (c *AppController) SubscribeV2Issue101Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue101TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -299,7 +299,7 @@ func (c *AppController) UnsubscribeV2Issue101Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/122/asyncapi.gen.go
+++ b/test/v2/issues/122/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -195,17 +195,17 @@ func (c *AppController) SubscribeV2Issue122Msg(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -213,7 +213,7 @@ func (c *AppController) SubscribeV2Issue122Msg(
 			// Listen to next message
 			stop, err := c.listenToV2Issue122MsgNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -299,7 +299,7 @@ func (c *AppController) UnsubscribeV2Issue122Msg(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/131/asyncapi.gen.go
+++ b/test/v2/issues/131/asyncapi.gen.go
@@ -281,7 +281,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -321,17 +321,17 @@ func (c *UserController) SubscribeV2Issue131Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -339,7 +339,7 @@ func (c *UserController) SubscribeV2Issue131Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue131TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -425,7 +425,7 @@ func (c *UserController) UnsubscribeV2Issue131Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/164/asyncapi.gen.go
+++ b/test/v2/issues/164/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -196,17 +196,17 @@ func (c *AppController) SubscribeV2Issue164TestMap(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -214,7 +214,7 @@ func (c *AppController) SubscribeV2Issue164TestMap(
 			// Listen to next message
 			stop, err := c.listenToV2Issue164TestMapNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -300,7 +300,7 @@ func (c *AppController) UnsubscribeV2Issue164TestMap(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/169/asyncapi.gen.go
+++ b/test/v2/issues/169/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -195,17 +195,17 @@ func (c *AppController) SubscribeV2Issue169Msg(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -213,7 +213,7 @@ func (c *AppController) SubscribeV2Issue169Msg(
 			// Listen to next message
 			stop, err := c.listenToV2Issue169MsgNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -299,7 +299,7 @@ func (c *AppController) UnsubscribeV2Issue169Msg(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/186/asyncapi.gen.go
+++ b/test/v2/issues/186/asyncapi.gen.go
@@ -158,7 +158,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeV2Issue186Angle(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeV2Issue186Angle(
 			// Listen to next message
 			stop, err := c.listenToV2Issue186AngleNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -306,7 +306,7 @@ func (c *AppController) UnsubscribeV2Issue186Angle(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeV2Issue186Star will subscribe to new messages from 'v2.issue186.star.*.*' channel.
@@ -327,17 +327,17 @@ func (c *AppController) SubscribeV2Issue186Star(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -345,7 +345,7 @@ func (c *AppController) SubscribeV2Issue186Star(
 			// Listen to next message
 			stop, err := c.listenToV2Issue186StarNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -431,7 +431,7 @@ func (c *AppController) UnsubscribeV2Issue186Star(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/220/camel/asyncapi.gen.go
+++ b/test/v2/issues/220/camel/asyncapi.gen.go
@@ -281,7 +281,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -321,17 +321,17 @@ func (c *UserController) SubscribeV2Issue220Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -339,7 +339,7 @@ func (c *UserController) SubscribeV2Issue220Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue220TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -425,7 +425,7 @@ func (c *UserController) UnsubscribeV2Issue220Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/220/none/asyncapi.gen.go
+++ b/test/v2/issues/220/none/asyncapi.gen.go
@@ -281,7 +281,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -321,17 +321,17 @@ func (c *UserController) SubscribeV2Issue220Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -339,7 +339,7 @@ func (c *UserController) SubscribeV2Issue220Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue220TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -425,7 +425,7 @@ func (c *UserController) UnsubscribeV2Issue220Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/222/asyncapi.gen.go
+++ b/test/v2/issues/222/asyncapi.gen.go
@@ -284,7 +284,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -324,17 +324,17 @@ func (c *UserController) SubscribeV2Issue222Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -342,7 +342,7 @@ func (c *UserController) SubscribeV2Issue222Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue222TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -428,7 +428,7 @@ func (c *UserController) UnsubscribeV2Issue222Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/245/asyncapi.gen.go
+++ b/test/v2/issues/245/asyncapi.gen.go
@@ -281,7 +281,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -321,17 +321,17 @@ func (c *UserController) SubscribeV2Issue245Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -339,7 +339,7 @@ func (c *UserController) SubscribeV2Issue245Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue245TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -425,7 +425,7 @@ func (c *UserController) UnsubscribeV2Issue245Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/267/asyncapi.gen.go
+++ b/test/v2/issues/267/asyncapi.gen.go
@@ -281,7 +281,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -321,17 +321,17 @@ func (c *UserController) SubscribeV2Issue267Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -339,7 +339,7 @@ func (c *UserController) SubscribeV2Issue267Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue267TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -425,7 +425,7 @@ func (c *UserController) UnsubscribeV2Issue267Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/290/asyncapi.gen.go
+++ b/test/v2/issues/290/asyncapi.gen.go
@@ -281,7 +281,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -321,17 +321,17 @@ func (c *UserController) SubscribeTestCreated(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -339,7 +339,7 @@ func (c *UserController) SubscribeTestCreated(
 			// Listen to next message
 			stop, err := c.listenToTestCreatedNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -425,7 +425,7 @@ func (c *UserController) UnsubscribeTestCreated(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/49/asyncapi.gen.go
+++ b/test/v2/issues/49/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -195,17 +195,17 @@ func (c *AppController) SubscribeV2Issue49Chat(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -213,7 +213,7 @@ func (c *AppController) SubscribeV2Issue49Chat(
 			// Listen to next message
 			stop, err := c.listenToV2Issue49ChatNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -299,7 +299,7 @@ func (c *AppController) UnsubscribeV2Issue49Chat(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishV2Issue49Chat will publish messages to 'v2.issue49.chat' channel
@@ -463,7 +463,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -507,17 +507,17 @@ func (c *UserController) SubscribeV2Issue49Chat(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -525,7 +525,7 @@ func (c *UserController) SubscribeV2Issue49Chat(
 			// Listen to next message
 			stop, err := c.listenToV2Issue49ChatNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -611,7 +611,7 @@ func (c *UserController) UnsubscribeV2Issue49Chat(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeV2Issue49Status will subscribe to new messages from 'v2.issue49.status' channel.
@@ -632,17 +632,17 @@ func (c *UserController) SubscribeV2Issue49Status(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -650,7 +650,7 @@ func (c *UserController) SubscribeV2Issue49Status(
 			// Listen to next message
 			stop, err := c.listenToV2Issue49StatusNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -736,7 +736,7 @@ func (c *UserController) UnsubscribeV2Issue49Status(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // PublishV2Issue49Chat will publish messages to 'v2.issue49.chat' channel

--- a/test/v2/issues/73/v1/asyncapi.gen.go
+++ b/test/v2/issues/73/v1/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -195,17 +195,17 @@ func (c *AppController) SubscribeV2Issue73Hello(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -213,7 +213,7 @@ func (c *AppController) SubscribeV2Issue73Hello(
 			// Listen to next message
 			stop, err := c.listenToV2Issue73HelloNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -299,7 +299,7 @@ func (c *AppController) UnsubscribeV2Issue73Hello(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/73/v2/asyncapi.gen.go
+++ b/test/v2/issues/73/v2/asyncapi.gen.go
@@ -157,7 +157,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -197,17 +197,17 @@ func (c *AppController) SubscribeV2Issue73Hello(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -215,7 +215,7 @@ func (c *AppController) SubscribeV2Issue73Hello(
 			// Listen to next message
 			stop, err := c.listenToV2Issue73HelloNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -301,7 +301,7 @@ func (c *AppController) UnsubscribeV2Issue73Hello(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/74/asyncapi.gen.go
+++ b/test/v2/issues/74/asyncapi.gen.go
@@ -157,7 +157,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -197,17 +197,17 @@ func (c *AppController) SubscribeV2Issue74TestChannel(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -215,7 +215,7 @@ func (c *AppController) SubscribeV2Issue74TestChannel(
 			// Listen to next message
 			stop, err := c.listenToV2Issue74TestChannelNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -301,7 +301,7 @@ func (c *AppController) UnsubscribeV2Issue74TestChannel(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v2/issues/97/asyncapi.gen.go
+++ b/test/v2/issues/97/asyncapi.gen.go
@@ -341,7 +341,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -389,17 +389,17 @@ func (c *UserController) SubscribeV2Issue97ReferencePayloadArray(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -407,7 +407,7 @@ func (c *UserController) SubscribeV2Issue97ReferencePayloadArray(
 			// Listen to next message
 			stop, err := c.listenToV2Issue97ReferencePayloadArrayNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -493,7 +493,7 @@ func (c *UserController) UnsubscribeV2Issue97ReferencePayloadArray(ctx context.C
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeV2Issue97ReferencePayloadObject will subscribe to new messages from 'v2.issue97.referencePayloadObject' channel.
@@ -514,17 +514,17 @@ func (c *UserController) SubscribeV2Issue97ReferencePayloadObject(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -532,7 +532,7 @@ func (c *UserController) SubscribeV2Issue97ReferencePayloadObject(
 			// Listen to next message
 			stop, err := c.listenToV2Issue97ReferencePayloadObjectNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -618,7 +618,7 @@ func (c *UserController) UnsubscribeV2Issue97ReferencePayloadObject(ctx context.
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeV2Issue97ReferencePayloadString will subscribe to new messages from 'v2.issue97.referencePayloadString' channel.
@@ -639,17 +639,17 @@ func (c *UserController) SubscribeV2Issue97ReferencePayloadString(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -657,7 +657,7 @@ func (c *UserController) SubscribeV2Issue97ReferencePayloadString(
 			// Listen to next message
 			stop, err := c.listenToV2Issue97ReferencePayloadStringNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -743,7 +743,7 @@ func (c *UserController) UnsubscribeV2Issue97ReferencePayloadString(ctx context.
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v2/issues/99/asyncapi.gen.go
+++ b/test/v2/issues/99/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeAll(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeAll will subscribe to channels without parameters on which the app is expecting messages.
@@ -195,17 +195,17 @@ func (c *AppController) SubscribeV2Issue99Test(
 	_, exists := c.subscriptions[path]
 	if exists {
 		err := fmt.Errorf("%w: %q channel is already subscribed", extensions.ErrAlreadySubscribedChannel, path)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, path)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app subscriber
 	go func() {
@@ -213,7 +213,7 @@ func (c *AppController) SubscribeV2Issue99Test(
 			// Listen to next message
 			stop, err := c.listenToV2Issue99TestNextMessage(path, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -299,7 +299,7 @@ func (c *AppController) UnsubscribeV2Issue99Test(ctx context.Context) {
 	// Remove if from the subscribers
 	delete(c.subscriptions, path)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides publishing capabilities to the

--- a/test/v3/issues/130/decoupling/asyncapi.gen.go
+++ b/test/v3/issues/130/decoupling/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToConsumeUserSignupOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToConsumeUserSignupOperation(
 			// Listen to next message
 			stop, err := c.listenToConsumeUserSignupOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromConsumeUserSignupOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/130/parameters/asyncapi.gen.go
+++ b/test/v3/issues/130/parameters/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -198,17 +198,17 @@ func (c *AppController) SubscribeToReceiveUserSignedUpOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -216,7 +216,7 @@ func (c *AppController) SubscribeToReceiveUserSignedUpOperation(
 			// Listen to next message
 			stop, err := c.listenToReceiveUserSignedUpOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -305,7 +305,7 @@ func (c *AppController) UnsubscribeFromReceiveUserSignedUpOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/130/requestreply/asyncapi.gen.go
+++ b/test/v3/issues/130/requestreply/asyncapi.gen.go
@@ -161,7 +161,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -211,17 +211,17 @@ func (c *AppController) SubscribeToPingOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -229,7 +229,7 @@ func (c *AppController) SubscribeToPingOperation(
 			// Listen to next message
 			stop, err := c.listenToPingOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -330,7 +330,7 @@ func (c *AppController) UnsubscribeFromPingOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 } // SubscribeToPingWithIDOperation will receive PingWithID messages from PingWithID channel.
 // Callback function 'fn' will be called each time a new message is received.
 //
@@ -353,17 +353,17 @@ func (c *AppController) SubscribeToPingWithIDOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -371,7 +371,7 @@ func (c *AppController) SubscribeToPingWithIDOperation(
 			// Listen to next message
 			stop, err := c.listenToPingWithIDOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -478,7 +478,7 @@ func (c *AppController) UnsubscribeFromPingWithIDOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingOperation will send a Pong message on Pong channel.
@@ -524,7 +524,7 @@ func (c *AppController) SendAsReplyToPingWithIDOperation(
 
 	// Set correlation ID if it does not exist
 	if id := msg.CorrelationID(); id == "" {
-		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error())
+		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error(), extensions.LogInfosFromContext(ctx)...)
 		return extensions.ErrNoCorrelationIDSet
 
 	}
@@ -700,10 +700,10 @@ func (c *UserController) RequestToPingOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -711,12 +711,12 @@ func (c *UserController) RequestToPingOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Send the message
 	if err := c.SendToPingOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -727,7 +727,7 @@ func (c *UserController) RequestToPingOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -757,7 +757,7 @@ func (c *UserController) waitForPingOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
@@ -783,7 +783,7 @@ func (c *UserController) waitForPingOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }
@@ -847,10 +847,10 @@ func (c *UserController) RequestToPingWithIDOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongWithIDMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -858,7 +858,7 @@ func (c *UserController) RequestToPingWithIDOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Set correlation ID if it does not exist
@@ -868,7 +868,7 @@ func (c *UserController) RequestToPingWithIDOperation(
 
 	// Send the message
 	if err := c.SendToPingWithIDOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongWithIDMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -879,7 +879,7 @@ func (c *UserController) RequestToPingWithIDOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongWithIDMessage{}, err
 		}
 
@@ -911,14 +911,14 @@ func (c *UserController) waitForPingWithIDOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		rmsg, err := brokerMessageToPongWithIDMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge the message
@@ -948,7 +948,7 @@ func (c *UserController) waitForPingWithIDOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/test/v3/issues/131/asyncapi.gen.go
+++ b/test/v3/issues/131/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 			// Listen to next message
 			stop, err := c.listenToReceiveTestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromReceiveTestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/139/asyncapi.gen.go
+++ b/test/v3/issues/139/asyncapi.gen.go
@@ -291,7 +291,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -333,17 +333,17 @@ func (c *UserController) SubscribeToSendUserOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -351,7 +351,7 @@ func (c *UserController) SubscribeToSendUserOperation(
 			// Listen to next message
 			stop, err := c.listenToSendUserOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -440,7 +440,7 @@ func (c *UserController) UnsubscribeFromSendUserOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v3/issues/140/asyncapi.gen.go
+++ b/test/v3/issues/140/asyncapi.gen.go
@@ -308,7 +308,7 @@ func (c *UserController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed user controller")
+	c.logger.Info(ctx, "Closed user controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -354,17 +354,17 @@ func (c *UserController) SubscribeToSendEventsOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -372,7 +372,7 @@ func (c *UserController) SubscribeToSendEventsOperation(
 			// Listen to next message
 			stop, err := c.listenToSendEventsOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -460,7 +460,7 @@ func (c *UserController) UnsubscribeFromSendEventsOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // AsyncAPIVersion is the version of the used AsyncAPI document

--- a/test/v3/issues/141/asyncapi.gen.go
+++ b/test/v3/issues/141/asyncapi.gen.go
@@ -158,7 +158,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -204,17 +204,17 @@ func (c *AppController) SubscribeToPingOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -222,7 +222,7 @@ func (c *AppController) SubscribeToPingOperation(
 			// Listen to next message
 			stop, err := c.listenToPingOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -329,7 +329,7 @@ func (c *AppController) UnsubscribeFromPingOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingOperation will send a Pong message on Pong channel.
@@ -345,7 +345,7 @@ func (c *AppController) SendAsReplyToPingOperation(
 
 	// Set correlation ID if it does not exist
 	if id := msg.CorrelationID(); id == "" {
-		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error())
+		c.logger.Error(ctx, extensions.ErrNoCorrelationIDSet.Error(), extensions.LogInfosFromContext(ctx)...)
 		return extensions.ErrNoCorrelationIDSet
 
 	}
@@ -527,10 +527,10 @@ func (c *UserController) RequestToPingOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -538,7 +538,7 @@ func (c *UserController) RequestToPingOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Set correlation ID if it does not exist
@@ -548,7 +548,7 @@ func (c *UserController) RequestToPingOperation(
 
 	// Send the message
 	if err := c.SendToPingOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -559,7 +559,7 @@ func (c *UserController) RequestToPingOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -591,14 +591,14 @@ func (c *UserController) waitForPingOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
 		// Get new message
 		rmsg, err := brokerMessageToPongMessage(acknowledgeableBrokerMessage.BrokerMessage)
 		if err != nil {
-			c.logger.Error(msgCtx, err.Error())
+			c.logger.Error(msgCtx, err.Error(), extensions.LogInfosFromContext(msgCtx)...)
 		}
 
 		// Acknowledge the message
@@ -628,7 +628,7 @@ func (c *UserController) waitForPingOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/test/v3/issues/145/asyncapi.gen.go
+++ b/test/v3/issues/145/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToPingRequestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToPingRequestOperation(
 			// Listen to next message
 			stop, err := c.listenToPingRequestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -326,7 +326,7 @@ func (c *AppController) UnsubscribeFromPingRequestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingRequestOperation will send a Pong message on Pong channel.
@@ -514,10 +514,10 @@ func (c *UserController) RequestToPingRequestOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -525,12 +525,12 @@ func (c *UserController) RequestToPingRequestOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Send the message
 	if err := c.SendToPingRequestOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -541,7 +541,7 @@ func (c *UserController) RequestToPingRequestOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -571,7 +571,7 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
@@ -597,7 +597,7 @@ func (c *UserController) waitForPingRequestOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/test/v3/issues/148/asyncapi.gen.go
+++ b/test/v3/issues/148/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -201,17 +201,17 @@ func (c *AppController) SubscribeToGetServiceInfoOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -219,7 +219,7 @@ func (c *AppController) SubscribeToGetServiceInfoOperation(
 			// Listen to next message
 			stop, err := c.listenToGetServiceInfoOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -325,7 +325,7 @@ func (c *AppController) UnsubscribeFromGetServiceInfoOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToGetServiceInfoOperation will send a ReplyMessageFromReplyChannel message on Reply channel.
@@ -513,10 +513,10 @@ func (c *UserController) RequestToGetServiceInfoOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return ReplyMessageFromReplyChannel{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -524,12 +524,12 @@ func (c *UserController) RequestToGetServiceInfoOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Send the message
 	if err := c.SendToGetServiceInfoOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return ReplyMessageFromReplyChannel{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -540,7 +540,7 @@ func (c *UserController) RequestToGetServiceInfoOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return ReplyMessageFromReplyChannel{}, err
 		}
 
@@ -570,7 +570,7 @@ func (c *UserController) waitForGetServiceInfoOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
@@ -596,7 +596,7 @@ func (c *UserController) waitForGetServiceInfoOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/test/v3/issues/162/asyncapi.gen.go
+++ b/test/v3/issues/162/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) ListenForPing(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) ListenForPing(
 			// Listen to next message
 			stop, err := c.listenToPingOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -321,7 +321,7 @@ func (c *AppController) UnsubscribeFromPingOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingOperation will send a Pong message on Pong channel.
@@ -505,10 +505,10 @@ func (c *UserController) AskPing(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -516,12 +516,12 @@ func (c *UserController) AskPing(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Send the message
 	if err := c.PublishPing(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -532,7 +532,7 @@ func (c *UserController) AskPing(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -562,7 +562,7 @@ func (c *UserController) waitForPingOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
@@ -588,7 +588,7 @@ func (c *UserController) waitForPingOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/test/v3/issues/164/asyncapi.gen.go
+++ b/test/v3/issues/164/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToTestMapOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToTestMapOperation(
 			// Listen to next message
 			stop, err := c.listenToTestMapOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromTestMapOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/181/asyncapi.gen.go
+++ b/test/v3/issues/181/asyncapi.gen.go
@@ -155,7 +155,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -201,17 +201,17 @@ func (c *AppController) SubscribeToGetServiceInfoOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -219,7 +219,7 @@ func (c *AppController) SubscribeToGetServiceInfoOperation(
 			// Listen to next message
 			stop, err := c.listenToGetServiceInfoOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -322,7 +322,7 @@ func (c *AppController) UnsubscribeFromGetServiceInfoOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToGetServiceInfoOperation will send a ReplyMessageFromReplyChannel message on Reply channel.
@@ -507,10 +507,10 @@ func (c *UserController) RequestToGetServiceInfoOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return ReplyMessageFromReplyChannel{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -518,12 +518,12 @@ func (c *UserController) RequestToGetServiceInfoOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Send the message
 	if err := c.SendToGetServiceInfoOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return ReplyMessageFromReplyChannel{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -534,7 +534,7 @@ func (c *UserController) RequestToGetServiceInfoOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return ReplyMessageFromReplyChannel{}, err
 		}
 
@@ -564,7 +564,7 @@ func (c *UserController) waitForGetServiceInfoOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
@@ -590,7 +590,7 @@ func (c *UserController) waitForGetServiceInfoOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }

--- a/test/v3/issues/186/asyncapi.gen.go
+++ b/test/v3/issues/186/asyncapi.gen.go
@@ -158,7 +158,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -208,17 +208,17 @@ func (c *AppController) SubscribeToAngleRequestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -226,7 +226,7 @@ func (c *AppController) SubscribeToAngleRequestOperation(
 			// Listen to next message
 			stop, err := c.listenToAngleRequestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -314,7 +314,7 @@ func (c *AppController) UnsubscribeFromAngleRequestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 } // SubscribeToStarRequestOperation will receive Star messages from Star channel.
 // Callback function 'fn' will be called each time a new message is received.
 //
@@ -337,17 +337,17 @@ func (c *AppController) SubscribeToStarRequestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -355,7 +355,7 @@ func (c *AppController) SubscribeToStarRequestOperation(
 			// Listen to next message
 			stop, err := c.listenToStarRequestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -443,7 +443,7 @@ func (c *AppController) UnsubscribeFromStarRequestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/220/camel/asyncapi.gen.go
+++ b/test/v3/issues/220/camel/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToHandlingTestingOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToHandlingTestingOperation(
 			// Listen to next message
 			stop, err := c.listenToHandlingTestingOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromHandlingTestingOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/220/none/asyncapi.gen.go
+++ b/test/v3/issues/220/none/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToHandlingTestingOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToHandlingTestingOperation(
 			// Listen to next message
 			stop, err := c.listenToHandlingTestingOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromHandlingTestingOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/222/asyncapi.gen.go
+++ b/test/v3/issues/222/asyncapi.gen.go
@@ -159,7 +159,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -205,17 +205,17 @@ func (c *AppController) SubscribeToHandleTestingOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -223,7 +223,7 @@ func (c *AppController) SubscribeToHandleTestingOperation(
 			// Listen to next message
 			stop, err := c.listenToHandleTestingOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -311,7 +311,7 @@ func (c *AppController) UnsubscribeFromHandleTestingOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/224/asyncapi.gen.go
+++ b/test/v3/issues/224/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 			// Listen to next message
 			stop, err := c.listenToReceiveTestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromReceiveTestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/245/asyncapi.gen.go
+++ b/test/v3/issues/245/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 			// Listen to next message
 			stop, err := c.listenToReceiveTestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromReceiveTestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/267/asyncapi.gen.go
+++ b/test/v3/issues/267/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToReceiveTestOperation(
 			// Listen to next message
 			stop, err := c.listenToReceiveTestOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -308,7 +308,7 @@ func (c *AppController) UnsubscribeFromReceiveTestOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // UserController is the structure that provides sending capabilities to the

--- a/test/v3/issues/292/asyncapi.gen.go
+++ b/test/v3/issues/292/asyncapi.gen.go
@@ -156,7 +156,7 @@ func (c *AppController) Close(ctx context.Context) {
 	// Unsubscribing remaining channels
 	c.UnsubscribeFromAllChannels(ctx)
 
-	c.logger.Info(ctx, "Closed app controller")
+	c.logger.Info(ctx, "Closed app controller", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SubscribeToAllChannels will receive messages from channels where channel has
@@ -202,17 +202,17 @@ func (c *AppController) SubscribeToPingOperation(
 	_, exists := c.subscriptions[addr]
 	if exists {
 		err := fmt.Errorf("%w: controller is already subscribed on channel %q", extensions.ErrAlreadySubscribedChannel, addr)
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
 
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Asynchronously listen to new messages and pass them to app receiver
 	go func() {
@@ -220,7 +220,7 @@ func (c *AppController) SubscribeToPingOperation(
 			// Listen to next message
 			stop, err := c.listenToPingOperationNextMessage(addr, sub, fn)
 			if err != nil {
-				c.logger.Error(ctx, err.Error())
+				c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			}
 
 			// Stop if required
@@ -321,7 +321,7 @@ func (c *AppController) UnsubscribeFromPingOperation(
 	// Remove if from the receivers
 	delete(c.subscriptions, addr)
 
-	c.logger.Info(ctx, "Unsubscribed from channel")
+	c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 }
 
 // SendAsReplyToPingOperation will send a Pong message on Pong channel.
@@ -505,10 +505,10 @@ func (c *UserController) RequestToPingOperation(
 	// Subscribe to broker channel
 	sub, err := c.broker.Subscribe(ctx, addr)
 	if err != nil {
-		c.logger.Error(ctx, err.Error())
+		c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 		return PongMessage{}, err
 	}
-	c.logger.Info(ctx, "Subscribed to channel")
+	c.logger.Info(ctx, "Subscribed to channel", extensions.LogInfosFromContext(ctx)...)
 
 	// Close receiver on leave
 	defer func() {
@@ -516,12 +516,12 @@ func (c *UserController) RequestToPingOperation(
 		sub.Cancel(ctx)
 
 		// Logging unsubscribing
-		c.logger.Info(ctx, "Unsubscribed from channel")
+		c.logger.Info(ctx, "Unsubscribed from channel", extensions.LogInfosFromContext(ctx)...)
 	}()
 
 	// Send the message
 	if err := c.SendToPingOperation(ctx, msg); err != nil {
-		c.logger.Error(ctx, "error happened when sending message", extensions.LogInfo{Key: "error", Value: err.Error()})
+		c.logger.Error(ctx, "error happened when sending message", append(extensions.LogInfosFromContext(ctx), extensions.LogInfo{Key: "error", Value: err.Error()})...)
 		return PongMessage{}, fmt.Errorf("error happened when sending message: %w", err)
 	}
 
@@ -532,7 +532,7 @@ func (c *UserController) RequestToPingOperation(
 		if err != nil {
 			// Return on error (e.g. context canceled or subscription closed)
 			// instead of looping forever
-			c.logger.Error(ctx, err.Error())
+			c.logger.Error(ctx, err.Error(), extensions.LogInfosFromContext(ctx)...)
 			return PongMessage{}, err
 		}
 
@@ -562,7 +562,7 @@ func (c *UserController) waitForPingOperationNextResponse(
 		// (i.e. uninitialized message), then the subscription ended before
 		// receiving the expected message
 		if !open && acknowledgeableBrokerMessage.IsUninitialized() {
-			c.logger.Error(msgCtx, "Channel closed before getting message")
+			c.logger.Error(msgCtx, "Channel closed before getting message", extensions.LogInfosFromContext(msgCtx)...)
 			return nil, extensions.ErrSubscriptionCanceled
 		}
 
@@ -588,7 +588,7 @@ func (c *UserController) waitForPingOperationNextResponse(
 
 		return &rmsg, nil
 	case <-ctx.Done(): // Set corresponding error if context is done
-		c.logger.Error(msgCtx, "Context done before getting message")
+		c.logger.Error(msgCtx, "Context done before getting message", extensions.LogInfosFromContext(msgCtx)...)
 		return nil, extensions.ErrContextCanceled
 	}
 }


### PR DESCRIPTION
Closes #334. Follow-up to #133 / #331 — completes the breaking part.

## What

Stop relying on the `context.Context` to carry logging metadata into the loggers.

- **Generated code** (v2 & v3 controller templates): every `c.logger.Info/Warning/Error(...)` call now attaches the contextual values explicitly via `extensions.LogInfosFromContext(ctx)...`. The single call site that already passes extra info uses `append(extensions.LogInfosFromContext(ctx), …)...`.
- **Built-in loggers** (`Text`, `ECS`): dropped `setInfoFromContext`; they no longer read from the context and log only what they are given (plus the intrinsic `message`/`@timestamp`/`log.*` keys).
- The context values are **still set** in the generated code, so anything else relying on them keeps working — only the loggers stop reading from it.

## Design decision

`LogInfosFromContext` emits **generic** keys (`channel`, `correlationID`, `brokerMessage`, `direction`, `provider`, `version`) and is the single source of truth. The loggers are now **pure pass-through**: they print those generic keys rather than re-mapping them.

> **BREAKING:** the built-in `Text`/`ECS` loggers now emit the generic keys instead of their previous custom names (e.g. ECS no longer maps to `trace.id`, `event.action`, `event.original`; Text no longer uses `Channel`/`CorrelationID`/`Content`). Custom loggers now receive everything as arguments and never have to unwrap context keys. Documented as a migration note in the README.

## Scope / acceptance

- [x] Generated controller code attaches the contextual `LogInfo`s explicitly at each log call.
- [x] `Text` and `ECS` loggers no longer call `setInfoFromContext`.
- [x] Migration/compatibility story documented (README custom-logging section).
- [x] Regenerated all golden files (52 `*.gen.go`); examples updated.
- [x] Added pass-through tests for the built-in loggers.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./pkg/codegen/... ./pkg/extensions/...` pass (broker integration tests requiring a live NATS server are excluded — unrelated)
- `golangci-lint` clean on changed packages and sample generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)